### PR TITLE
Union data

### DIFF
--- a/code.go
+++ b/code.go
@@ -68,11 +68,11 @@ type LCode struct {
 	name     string
 	ops      []int
 	argc     int
-	defaults []*LAny
-	keys     []*LAny
+	defaults []*LOB
+	keys     []*LOB
 }
 
-func newCode(argc int, defaults []*LAny, keys []*LAny, name string) *LAny {
+func newCode(argc int, defaults []*LOB, keys []*LOB, name string) *LOB {
 	var ops []int
 	code := &LCode{
 		name,
@@ -81,8 +81,7 @@ func newCode(argc int, defaults []*LAny, keys []*LAny, name string) *LAny {
 		defaults, //nil for normal procs, empty for rest, and non-empty for optional/keyword
 		keys,
 	}
-	result := new(LAny)
-	result.ltype = typeCode
+	result := newLOB(typeCode)
 	result.code = code
 	return result
 }
@@ -234,7 +233,7 @@ func (code *LCode) String() string {
 	//	return fmt.Sprintf("(function (%d %v %s) %v)", code.argc, code.defaults, code.keys, code.ops)
 }
 
-func (code *LCode) loadOps(lst *LAny) error {
+func (code *LCode) loadOps(lst *LOB) error {
 	for lst != EmptyList {
 		instr := car(lst)
 		op := car(instr)
@@ -248,8 +247,8 @@ func (code *LCode) loadOps(lst *LAny) error {
 			funcParams := car(lstFunc)
 			var argc int
 			var name string
-			var defaults []*LAny
-			var keys []*LAny
+			var defaults []*LOB
+			var keys []*LOB
 			var err error
 			if isSymbol(funcParams) {
 				//legacy form, just the argc
@@ -259,7 +258,7 @@ func (code *LCode) loadOps(lst *LAny) error {
 				}
 				if argc < 0 {
 					argc = -argc - 1
-					defaults = make([]*LAny, 0)
+					defaults = make([]*LOB, 0)
 				}
 			} else if isList(funcParams) && length(funcParams) == 4 {
 				tmp := funcParams
@@ -363,12 +362,12 @@ func (code *LCode) loadOps(lst *LAny) error {
 	return nil
 }
 
-func (code *LCode) emitLiteral(val *LAny) {
+func (code *LCode) emitLiteral(val *LOB) {
 	code.ops = append(code.ops, opcodeLiteral)
 	code.ops = append(code.ops, putConstant(val))
 }
 
-func (code *LCode) emitGlobal(sym *LAny) {
+func (code *LCode) emitGlobal(sym *LOB) {
 	code.ops = append(code.ops, opcodeGlobal)
 	code.ops = append(code.ops, int(sym.ival))
 }
@@ -401,19 +400,19 @@ func (code *LCode) emitSetLocal(i int, j int) {
 	code.ops = append(code.ops, i)
 	code.ops = append(code.ops, j)
 }
-func (code *LCode) emitDefGlobal(sym *LAny) {
+func (code *LCode) emitDefGlobal(sym *LOB) {
 	code.ops = append(code.ops, opcodeDefGlobal)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *LCode) emitUndefGlobal(sym *LAny) {
+func (code *LCode) emitUndefGlobal(sym *LOB) {
 	code.ops = append(code.ops, opcodeUndefGlobal)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *LCode) emitDefMacro(sym *LAny) {
+func (code *LCode) emitDefMacro(sym *LOB) {
 	code.ops = append(code.ops, opcodeDefMacro)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *LCode) emitClosure(newCode *LAny) {
+func (code *LCode) emitClosure(newCode *LOB) {
 	code.ops = append(code.ops, opcodeClosure)
 	code.ops = append(code.ops, putConstant(newCode))
 }
@@ -440,7 +439,7 @@ func (code *LCode) emitStruct(slen int) {
 	code.ops = append(code.ops, opcodeStruct)
 	code.ops = append(code.ops, slen)
 }
-func (code *LCode) emitUse(sym *LAny) {
+func (code *LCode) emitUse(sym *LOB) {
 	code.ops = append(code.ops, opcodeUse)
 	code.ops = append(code.ops, putConstant(sym))
 }

--- a/code.go
+++ b/code.go
@@ -63,72 +63,28 @@ var symOpUndefGlobal = intern("undefglobal")
 var symOpDefMacro = intern("defmacro")
 var symOpUse = intern("use")
 
-// Code - compiled Ell bytecode
-type Code struct {
+// LCode - compiled Ell bytecode
+type LCode struct {
 	name     string
 	ops      []int
 	argc     int
-	defaults []LAny
-	keys     []LAny
+	defaults []*LAny
+	keys     []*LAny
 }
 
-func newCode(argc int, defaults []LAny, keys []LAny, name string) *Code {
+func newCode(argc int, defaults []*LAny, keys []*LAny, name string) *LAny {
 	var ops []int
-	code := Code{
+	code := &LCode{
 		name,
 		ops,
 		argc,
 		defaults, //nil for normal procs, empty for rest, and non-empty for optional/keyword
 		keys,
 	}
-	return &code
+	return &LAny{ltype: typeCode, code: code}
 }
 
-var typeCode = intern("<code>")
-
-// Type returns the type of the code
-func (*Code) Type() LAny {
-	return typeCode
-}
-
-// Value returns the object itself for primitive types
-func (code *Code) Value() LAny {
-	return code
-}
-
-// Equal returns true if the object is equal to the argument
-func (code *Code) Equal(another LAny) bool {
-	if c, ok := another.(*Code); ok {
-		return code == c
-	}
-	return false
-}
-
-func copyElements(elements []LAny) []LAny {
-	if elements == nil {
-		return nil
-	}
-	size := len(elements)
-	c := make([]LAny, size)
-	for i := 0; i < size; i++ {
-		c[i] = elements[i].Copy()
-	}
-	return c
-}
-
-func (code *Code) Copy() LAny {
-	ops := make([]int, len(code.ops))
-	copy(ops, code.ops)
-	return &Code{
-		code.name,
-		ops,
-		code.argc,
-		copyElements(code.defaults), //nil for normal procs, empty for rest, and non-empty for optional/keyword
-		copyElements(code.keys),
-	}
-}
-
-func (code *Code) signature() string {
+func (code *LCode) signature() string {
 	//
 	//experimental: external annotations on the functions: *declarations* is a map from symbol to string
 	//
@@ -141,8 +97,8 @@ func (code *Code) signature() string {
 	// (declare cons (<any> <list>) <list>)
 	if code.name != "" {
 		val := global(intern("*declarations*")) //so if this this has not been defined, we'll just skip it
-		if s, ok := val.(*LStruct); ok {
-			sig, _ := get(s, intern(code.name))
+		if val != nil && isStruct(val) {
+			sig, _ := get(val, intern(code.name))
 			if sig != Null {
 				return sig.String()
 			}
@@ -164,14 +120,14 @@ func (code *Code) signature() string {
 	return tmp
 }
 
-func (code *Code) decompile(pretty bool) string {
+func (code *LCode) decompile(pretty bool) string {
 	var buf bytes.Buffer
 	code.decompileInto(&buf, "", pretty)
 	s := buf.String()
 	return strings.Replace(s, "(function (\"\" 0 [] [])", "(code", 1)
 }
 
-func (code *Code) decompileInto(buf *bytes.Buffer, indent string, pretty bool) {
+func (code *LCode) decompileInto(buf *bytes.Buffer, indent string, pretty bool) {
 	indentAmount := "   "
 	offset := 0
 	max := len(code.ops)
@@ -230,7 +186,7 @@ func (code *Code) decompileInto(buf *bytes.Buffer, indent string, pretty bool) {
 			if pretty {
 				indent2 = indent + indentAmount
 			}
-			(constants[code.ops[offset+1]].(*Code)).decompileInto(buf, indent2, pretty)
+			constants[code.ops[offset+1]].code.decompileInto(buf, indent2, pretty)
 			buf.WriteString(")")
 			offset += 2
 		case opcodeLocal:
@@ -270,12 +226,12 @@ func (code *Code) decompileInto(buf *bytes.Buffer, indent string, pretty bool) {
 	buf.WriteString(")")
 }
 
-func (code *Code) String() string {
+func (code *LCode) String() string {
 	return code.decompile(true)
 	//	return fmt.Sprintf("(function (%d %v %s) %v)", code.argc, code.defaults, code.keys, code.ops)
 }
 
-func (code *Code) loadOps(lst LAny) error {
+func (code *LCode) loadOps(lst *LAny) error {
 	for lst != EmptyList {
 		instr := car(lst)
 		op := car(instr)
@@ -289,8 +245,8 @@ func (code *Code) loadOps(lst LAny) error {
 			funcParams := car(lstFunc)
 			var argc int
 			var name string
-			var defaults []LAny
-			var keys []LAny
+			var defaults []*LAny
+			var keys []*LAny
 			var err error
 			if isSymbol(funcParams) {
 				//legacy form, just the argc
@@ -300,13 +256,13 @@ func (code *Code) loadOps(lst LAny) error {
 				}
 				if argc < 0 {
 					argc = -argc - 1
-					defaults = make([]LAny, 0)
+					defaults = make([]*LAny, 0)
 				}
 			} else if isList(funcParams) && length(funcParams) == 4 {
 				tmp := funcParams
 				a := car(tmp)
 				tmp = cdr(tmp)
-				name, err = stringValue(a)
+				name, err = asString(a)
 				if err != nil {
 					return Error("Bad code format: ", funcParams)
 				}
@@ -318,18 +274,18 @@ func (code *Code) loadOps(lst LAny) error {
 				}
 				a = car(tmp)
 				tmp = cdr(tmp)
-				if ary, ok := a.(*LVector); ok {
-					defaults = ary.elements
+				if isVector(a) {
+					defaults = a.elements
 				}
 				a = car(tmp)
-				if ary, ok := a.(*LVector); ok {
-					keys = ary.elements
+				if isVector(a) {
+					keys = a.elements
 				}
 			} else {
 				return Error("Bad code format: ", funcParams)
 			}
 			fun := newCode(argc, defaults, keys, name)
-			fun.loadOps(cdr(lstFunc))
+			fun.code.loadOps(cdr(lstFunc))
 			code.emitClosure(fun)
 		case symOpLiteral:
 			code.emitLiteral(cadr(instr))
@@ -354,10 +310,11 @@ func (code *Code) loadOps(lst LAny) error {
 			}
 			code.emitSetLocal(i, j)
 		case symOpGlobal:
-			if sym, ok := cadr(instr).(*LSymbol); ok {
+			sym := cadr(instr)
+			if isSymbol(sym) {
 				code.emitGlobal(sym)
 			} else {
-				return Error(symOpGlobal, " argument 1 not a symbol: ", cadr(instr))
+				return Error(symOpGlobal, " argument 1 not a symbol: ", sym)
 			}
 		case symOpUndefGlobal:
 			code.emitUndefGlobal(cadr(instr))
@@ -403,84 +360,84 @@ func (code *Code) loadOps(lst LAny) error {
 	return nil
 }
 
-func (code *Code) emitLiteral(val LAny) {
+func (code *LCode) emitLiteral(val *LAny) {
 	code.ops = append(code.ops, opcodeLiteral)
 	code.ops = append(code.ops, putConstant(val))
 }
 
-func (code *Code) emitGlobal(sym *LSymbol) {
+func (code *LCode) emitGlobal(sym *LAny) {
 	code.ops = append(code.ops, opcodeGlobal)
-	code.ops = append(code.ops, sym.tag)
+	code.ops = append(code.ops, int(sym.ival))
 }
-func (code *Code) emitCall(argc int) {
+func (code *LCode) emitCall(argc int) {
 	code.ops = append(code.ops, opcodeCall)
 	code.ops = append(code.ops, argc)
 }
-func (code *Code) emitReturn() {
+func (code *LCode) emitReturn() {
 	code.ops = append(code.ops, opcodeReturn)
 }
-func (code *Code) emitTailCall(argc int) {
+func (code *LCode) emitTailCall(argc int) {
 	code.ops = append(code.ops, opcodeTailCall)
 	code.ops = append(code.ops, argc)
 }
-func (code *Code) emitPrimCall(prim *LPrimitive, argc int) {
+func (code *LCode) emitPrimCall(prim *LPrimitive, argc int) {
 	code.ops = append(code.ops, opcodePrimCall)
 	code.ops = append(code.ops, prim.idx)
 	code.ops = append(code.ops, argc)
 }
-func (code *Code) emitPop() {
+func (code *LCode) emitPop() {
 	code.ops = append(code.ops, opcodePop)
 }
-func (code *Code) emitLocal(i int, j int) {
+func (code *LCode) emitLocal(i int, j int) {
 	code.ops = append(code.ops, opcodeLocal)
 	code.ops = append(code.ops, i)
 	code.ops = append(code.ops, j)
 }
-func (code *Code) emitSetLocal(i int, j int) {
+func (code *LCode) emitSetLocal(i int, j int) {
 	code.ops = append(code.ops, opcodeSetLocal)
 	code.ops = append(code.ops, i)
 	code.ops = append(code.ops, j)
 }
-func (code *Code) emitDefGlobal(sym LAny) {
+func (code *LCode) emitDefGlobal(sym *LAny) {
 	code.ops = append(code.ops, opcodeDefGlobal)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *Code) emitUndefGlobal(sym LAny) {
+func (code *LCode) emitUndefGlobal(sym *LAny) {
 	code.ops = append(code.ops, opcodeUndefGlobal)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *Code) emitDefMacro(sym LAny) {
+func (code *LCode) emitDefMacro(sym *LAny) {
 	code.ops = append(code.ops, opcodeDefMacro)
 	code.ops = append(code.ops, putConstant(sym))
 }
-func (code *Code) emitClosure(newCode *Code) {
+func (code *LCode) emitClosure(newCode *LAny) {
 	code.ops = append(code.ops, opcodeClosure)
 	code.ops = append(code.ops, putConstant(newCode))
 }
-func (code *Code) emitJumpFalse(offset int) int {
+func (code *LCode) emitJumpFalse(offset int) int {
 	code.ops = append(code.ops, opcodeJumpFalse)
 	loc := len(code.ops)
 	code.ops = append(code.ops, offset)
 	return loc
 }
-func (code *Code) emitJump(offset int) int {
+func (code *LCode) emitJump(offset int) int {
 	code.ops = append(code.ops, opcodeJump)
 	loc := len(code.ops)
 	code.ops = append(code.ops, offset)
 	return loc
 }
-func (code *Code) setJumpLocation(loc int) {
+func (code *LCode) setJumpLocation(loc int) {
 	code.ops[loc] = len(code.ops) - loc + 1
 }
-func (code *Code) emitVector(alen int) {
+func (code *LCode) emitVector(alen int) {
 	code.ops = append(code.ops, opcodeVector)
 	code.ops = append(code.ops, alen)
 }
-func (code *Code) emitStruct(slen int) {
+func (code *LCode) emitStruct(slen int) {
 	code.ops = append(code.ops, opcodeStruct)
 	code.ops = append(code.ops, slen)
 }
-func (code *Code) emitUse(sym LAny) {
+func (code *LCode) emitUse(sym *LAny) {
 	code.ops = append(code.ops, opcodeUse)
 	code.ops = append(code.ops, putConstant(sym))
 }

--- a/code.go
+++ b/code.go
@@ -81,7 +81,10 @@ func newCode(argc int, defaults []*LAny, keys []*LAny, name string) *LAny {
 		defaults, //nil for normal procs, empty for rest, and non-empty for optional/keyword
 		keys,
 	}
-	return &LAny{ltype: typeCode, code: code}
+	result := new(LAny)
+	result.ltype = typeCode
+	result.code = code
+	return result
 }
 
 func (code *LCode) signature() string {
@@ -380,7 +383,7 @@ func (code *LCode) emitTailCall(argc int) {
 	code.ops = append(code.ops, opcodeTailCall)
 	code.ops = append(code.ops, argc)
 }
-func (code *LCode) emitPrimCall(prim *LPrimitive, argc int) {
+func (code *LCode) emitPrimCall(prim *Primitive, argc int) {
 	code.ops = append(code.ops, opcodePrimCall)
 	code.ops = append(code.ops, prim.idx)
 	code.ops = append(code.ops, argc)

--- a/compiler.go
+++ b/compiler.go
@@ -259,7 +259,7 @@ func compileExpr(target *LAny, env *LAny, expr *LAny, isTail bool, ignoreResult 
 
 func compileFn(target *LAny, env *LAny, args *LAny, body *LAny, isTail bool, ignoreResult bool, context string) error {
 	argc := 0
-	syms := []*LAny{}
+	var syms []*LAny
 	var defaults []*LAny
 	var keys []*LAny
 	tmp := args

--- a/data.go
+++ b/data.go
@@ -206,7 +206,10 @@ func instance(tag *LAny, val *LAny) (*LAny, error) {
 	if isPrimitiveType(tag) {
 		return val, nil
 	}
-	return &LAny{ltype: tag, car: val}, nil
+	result := new(LAny)
+	result.ltype = tag
+	result.car = val
+	return result, nil
 }
 
 func value(obj *LAny) *LAny {

--- a/ell.go
+++ b/ell.go
@@ -49,7 +49,6 @@ func initEnvironment() {
 
 	defineFunction("type", ellType, "(<any>) <type>")
 	defineFunction("value", ellValue, "<any>) <any>")
-	defineFunction("copy", ellCopy, "(<any>) <any>")
 	defineFunction("instance", ellInstance, "(<type> <any>) <any>")
 	defineFunction("normalize-keyword-args", ellNormalizeKeywordArgs, "(<list> <keyword>+) <list>")
 
@@ -68,7 +67,7 @@ func initEnvironment() {
 
 	defineFunction("keyword?", ellKeywordP, "(<any>) <boolean>")
 	defineFunction("string?", ellStringP, "(<any>) <boolean>")
-	defineFunction("char?", ellCharP, "(<any>) <boolean>")
+	defineFunction("character?", ellCharacterP, "(<any>) <boolean>")
 	defineFunction("function?", ellFunctionP, "(<any>) <boolean>")
 	defineFunction("eof?", ellFunctionP, "(<any>) <boolean>")
 
@@ -94,9 +93,9 @@ func initEnvironment() {
 	defineFunction("struct?", ellStructP, "(<any>) <boolean>")
 	defineFunction("has?", ellHasP, "(<struct> <any>) <boolean>")
 	defineFunction("get", ellGet, "(<struct> <any>) <any>")
-	defineFunction("assoc", ellAssoc, "(<struct> <any>) <struct")
-	defineFunction("dissoc", ellDissoc, "(<struct> <any>) <struct>")
 	defineFunction("put!", ellPutBang, "(<struct> <any> <any>) <null>") //mutate!
+	//	defineFunction("assoc", ellAssoc, "(<struct> <any>) <struct")
+	//	defineFunction("dissoc", ellDissoc, "(<struct> <any>) <struct>")
 
 	defineFunction("empty?", ellEmptyP, "(<any>) <boolean>")
 
@@ -142,29 +141,29 @@ func initEnvironment() {
 //expanders - these only gets called from the macro expander itself, so we know the single arg is an *LList
 //
 
-func ellLetrec(argv []LAny, argc int) (LAny, error) {
+func ellLetrec(argv []*LAny, argc int) (*LAny, error) {
 	return expandLetrec(argv[0])
 }
 
-func ellLet(argv []LAny, argc int) (LAny, error) {
+func ellLet(argv []*LAny, argc int) (*LAny, error) {
 	return expandLet(argv[0])
 }
 
-func ellCond(argv []LAny, argc int) (LAny, error) {
+func ellCond(argv []*LAny, argc int) (*LAny, error) {
 	return expandCond(argv[0])
 }
 
-func ellQuasiquote(argv []LAny, argc int) (LAny, error) {
+func ellQuasiquote(argv []*LAny, argc int) (*LAny, error) {
 	return expandQuasiquote(argv[0])
 }
 
 // functions
 
-func ellVersion(argv []LAny, argc int) (LAny, error) {
-	return LString(Version), nil
+func ellVersion(argv []*LAny, argc int) (*LAny, error) {
+	return newString(Version), nil
 }
 
-func ellDefinedP(argv []LAny, argc int) (LAny, error) {
+func ellDefinedP(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("defined?", "1", argc)
 	}
@@ -177,14 +176,14 @@ func ellDefinedP(argv []LAny, argc int) (LAny, error) {
 	return False, nil
 }
 
-func ellFileContents(argv []LAny, argc int) (LAny, error) {
+func ellFileContents(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("file-contents", "1", argc)
 	}
 	if !isString(argv[0]) {
 		return nil, ArgTypeError("string", 1, argv[0])
 	}
-	fname, err := stringValue(argv[0])
+	fname, err := asString(argv[0])
 	if err != nil {
 		return nil, err
 	}
@@ -192,58 +191,52 @@ func ellFileContents(argv []LAny, argc int) (LAny, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LString(s), nil
+	return newString(s), nil
 }
 
-func ellOpenInputString(argv []LAny, argc int) (LAny, error) {
+func ellOpenInputString(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("open-input-string", "1", argc)
 	}
-	if !isString(argv[0]) {
-		return nil, ArgTypeError("string", 1, argv[0])
-	}
-	s, err := stringValue(argv[0])
+	s, err := asString(argv[0])
 	if err != nil {
 		return nil, err
 	}
 	return openInputString(s), nil
 }
 
-func ellOpenInputFile(argv []LAny, argc int) (LAny, error) {
+func ellOpenInputFile(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("open-input-file", "1", argc)
 	}
-	if !isString(argv[0]) {
-		return nil, ArgTypeError("string", 1, argv[0])
-	}
-	s, err := stringValue(argv[0])
+	s, err := asString(argv[0])
 	if err != nil {
 		return nil, err
 	}
 	return openInputFile(s)
 }
 
-func ellRead(argv []LAny, argc int) (LAny, error) {
+func ellRead(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("read", "1", argc)
 	}
-	return readInput(argv[0])
+	return readInputPort(argv[0])
 }
-func ellCloseInput(argv []LAny, argc int) (LAny, error) {
+func ellCloseInput(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("read", "1", argc)
 	}
-	return nil, closeInput(argv[0])
+	return nil, closeInputPort(argv[0])
 }
 
-func ellMacroexpand(argv []LAny, argc int) (LAny, error) {
+func ellMacroexpand(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("macroexpand", "1", argc)
 	}
 	return macroexpand(argv[0])
 }
 
-func ellCompile(argv []LAny, argc int) (LAny, error) {
+func ellCompile(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("compile", "1", argc)
 	}
@@ -254,51 +247,44 @@ func ellCompile(argv []LAny, argc int) (LAny, error) {
 	return compile(expanded)
 }
 
-func ellType(argv []LAny, argc int) (LAny, error) {
+func ellType(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("type", "1", argc)
 	}
-	return argv[0].Type(), nil
+	return argv[0].ltype, nil
 }
 
-func ellValue(argv []LAny, argc int) (LAny, error) {
+func ellValue(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("value", "1", argc)
 	}
-	return argv[0].Value(), nil
+	return value(argv[0]), nil
 }
 
-func ellCopy(argv []LAny, argc int) (LAny, error) {
-	if argc != 1 {
-		return nil, ArgcError("copy", "1", argc)
-	}
-	return argv[0].Copy(), nil
-}
-
-func ellInstance(argv []LAny, argc int) (LAny, error) {
+func ellInstance(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 2 {
 		return nil, ArgcError("instance", "2", argc)
 	}
 	return instance(argv[0], argv[1])
 }
 
-func ellNormalizeKeywordArgs(argv []LAny, argc int) (LAny, error) {
+func ellNormalizeKeywordArgs(argv []*LAny, argc int) (*LAny, error) {
 	//(normalize-keyword-args '(x: 23) x: y:) -> (x:)
 	//(normalize-keyword-args '(x: 23 z: 100) x: y:) -> error("bad keyword z: in argument list")
 	if argc < 1 {
 		return nil, ArgcError("normalizeKeywordArgs", "1+", argc)
 	}
-	if args, ok := argv[0].(*LList); ok {
-		return normalizeKeywordArgs(args, argv[1:argc])
+	if isList(argv[0]) {
+		return normalizeKeywordArgs(argv[0], argv[1:argc])
 	}
 	return nil, ArgTypeError("list", 1, argv[0])
 }
 
-func ellStruct(argv []LAny, argc int) (LAny, error) {
+func ellStruct(argv []*LAny, argc int) (*LAny, error) {
 	return newStruct(argv[:argc])
 }
 
-func ellIdenticalP(argv []LAny, argc int) (LAny, error) {
+func ellIdenticalP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		b := identical(argv[0], argv[1])
 		if b {
@@ -309,7 +295,7 @@ func ellIdenticalP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("identical?", "2", argc)
 }
 
-func ellEq(argv []LAny, argc int) (LAny, error) {
+func ellEq(argv []*LAny, argc int) (*LAny, error) {
 	if argc < 1 {
 		return nil, ArgcError("eq?", "1+", argc)
 	}
@@ -322,20 +308,20 @@ func ellEq(argv []LAny, argc int) (LAny, error) {
 	return True, nil
 }
 
-func ellNumeq(argv []LAny, argc int) (LAny, error) {
+func ellNumeq(argv []*LAny, argc int) (*LAny, error) {
 	if argc < 1 {
 		return nil, ArgcError("=", "1+", argc)
 	}
 	obj := argv[0]
 	for i := 1; i < argc; i++ {
-		if b, err := numericallyEqual(obj, argv[1]); err != nil || !b {
-			return False, err
+		if b, err := numericallyEqual(obj, argv[1]); err != nil || b == False {
+			return b, err
 		}
 	}
 	return True, nil
 }
 
-func ellDisplay(argv []LAny, argc int) (LAny, error) {
+func ellDisplay(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("display", "1", argc)
@@ -344,7 +330,7 @@ func ellDisplay(argv []LAny, argc int) (LAny, error) {
 	return Null, nil
 }
 
-func ellWrite(argv []LAny, argc int) (LAny, error) {
+func ellWrite(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("write", "1", argc)
@@ -353,7 +339,7 @@ func ellWrite(argv []LAny, argc int) (LAny, error) {
 	return Null, nil
 }
 
-func ellNewline(argv []LAny, argc int) (LAny, error) {
+func ellNewline(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 0 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("newline", "0", argc)
@@ -362,7 +348,7 @@ func ellNewline(argv []LAny, argc int) (LAny, error) {
 	return Null, nil
 }
 
-func ellFatal(argv []LAny, argc int) (LAny, error) {
+func ellFatal(argv []*LAny, argc int) (*LAny, error) {
 	s := ""
 	for _, o := range argv {
 		s += fmt.Sprintf("%v", o)
@@ -370,81 +356,77 @@ func ellFatal(argv []LAny, argc int) (LAny, error) {
 	return nil, Error(s)
 }
 
-func ellToString(argv []LAny, argc int) (LAny, error) {
+func ellToString(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-string", "1", argc)
 	}
 	s := write(argv[0])
-	return LString(s), nil
+	return newString(s), nil
 }
 
-func ellPrint(argv []LAny, argc int) (LAny, error) {
+func ellPrint(argv []*LAny, argc int) (*LAny, error) {
 	for _, o := range argv {
 		fmt.Printf("%v", o)
 	}
 	return Null, nil
 }
 
-func ellPrintln(argv []LAny, argc int) (LAny, error) {
+func ellPrintln(argv []*LAny, argc int) (*LAny, error) {
 	ellPrint(argv, argc)
 	fmt.Println("")
 	return Null, nil
 }
 
-func ellConcat(argv []LAny, argc int) (LAny, error) {
+func ellConcat(argv []*LAny, argc int) (*LAny, error) {
 	result := EmptyList
 	tail := result
 	for i := 0; i < argc; i++ {
-		o := argv[i]
-		switch lst := o.(type) {
-		case *LList:
-			c := lst
-			for c != EmptyList {
-				if tail == EmptyList {
-					result = list(lst.car)
-					tail = result
-				} else {
-					tail.cdr = list(c.car)
-					tail = tail.cdr
-				}
-				c = c.cdr
+		lst := argv[i]
+		if !isList(lst) {
+			return nil, ArgTypeError("list", i+1, lst)
+		}
+		for lst != EmptyList {
+			if tail == EmptyList {
+				result = list(lst.car)
+				tail = result
+			} else {
+				tail.cdr = list(lst.car)
+				tail = tail.cdr
 			}
-		default:
-			return nil, ArgTypeError("list", i+1, o)
+			lst = lst.cdr
 		}
 	}
 	return result, nil
 }
 
-func ellReverse(argv []LAny, argc int) (LAny, error) {
+func ellReverse(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("reverse", "1", argc)
 	}
-	o := argv[0]
-	switch lst := o.(type) {
-	case *LList:
-		return reverse(lst), nil
-	default:
-		return nil, ArgTypeError("list", 1, o)
+	lst := argv[0]
+	if !isList(lst) {
+		return nil, ArgTypeError("list", 1, lst)
 	}
+	return reverse(lst), nil
 }
 
-func ellFlatten(argv []LAny, argc int) (LAny, error) {
+func ellFlatten(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("flatten", "1", argc)
 	}
-	switch t := argv[0].(type) {
-	case *LList:
-		return flatten(t), nil
-	case *LVector:
-		lst, _ := toList(t)
-		return flatten(lst.(*LList)), nil
+	seq := argv[0]
+	switch seq.ltype {
+	case typeList:
+		return flatten(seq), nil
+	case typeVector:
+		lst, _ := toList(seq)
+		return flatten(lst), nil
 	default:
-		return nil, ArgTypeError("list", 1, argv[0])
+		return nil, ArgTypeError("list", 1, seq)
 	}
 }
 
-func ellList(argv []LAny, argc int) (LAny, error) {
+func ellList(argv []*LAny, argc int) (*LAny, error) {
 	p := EmptyList
 	for i := argc - 1; i >= 0; i-- {
 		p = cons(argv[i], p)
@@ -452,7 +434,7 @@ func ellList(argv []LAny, argc int) (LAny, error) {
 	return p, nil
 }
 
-func ellNumberP(argv []LAny, argc int) (LAny, error) {
+func ellNumberP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isNumber(argv[0]) {
 			return True, nil
@@ -462,7 +444,7 @@ func ellNumberP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("number?", "1", argc)
 }
 
-func ellIntP(argv []LAny, argc int) (LAny, error) {
+func ellIntP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isInt(argv[0]) {
 			return True, nil
@@ -472,7 +454,7 @@ func ellIntP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("int?", "1", argc)
 }
 
-func ellFloatP(argv []LAny, argc int) (LAny, error) {
+func ellFloatP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isFloat(argv[0]) {
 			return True, nil
@@ -482,7 +464,7 @@ func ellFloatP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("float?", "1", argc)
 }
 
-func ellQuotient(argv []LAny, argc int) (LAny, error) {
+func ellQuotient(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		n1, err := int64Value(argv[0])
 		if err != nil {
@@ -495,12 +477,12 @@ func ellQuotient(argv []LAny, argc int) (LAny, error) {
 		if n2 == 0 {
 			return nil, Error("Quotient: divide by zero")
 		}
-		return LNumber(n1 / n2), nil
+		return newInt64(n1 / n2), nil
 	}
 	return nil, ArgcError("quotient", "2", argc)
 }
 
-func ellRemainder(argv []LAny, argc int) (LAny, error) {
+func ellRemainder(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		n1, err := int64Value(argv[0])
 		if err != nil {
@@ -513,47 +495,47 @@ func ellRemainder(argv []LAny, argc int) (LAny, error) {
 		if err != nil {
 			return nil, err
 		}
-		return LNumber(n1 % n2), nil
+		return newInt64(n1 % n2), nil
 	}
 	return nil, ArgcError("remainder", "2", argc)
 }
 
-func ellPlus(argv []LAny, argc int) (LAny, error) {
+func ellPlus(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		return add(argv[0], argv[1])
 	}
 	return sum(argv, argc)
 }
 
-func ellMinus(argv []LAny, argc int) (LAny, error) {
+func ellMinus(argv []*LAny, argc int) (*LAny, error) {
 	return minus(argv, argc)
 }
 
-func ellTimes(argv []LAny, argc int) (LAny, error) {
+func ellTimes(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		return mul(argv[0], argv[1])
 	}
 	return product(argv, argc)
 }
 
-func ellDiv(argv []LAny, argc int) (LAny, error) {
+func ellDiv(argv []*LAny, argc int) (*LAny, error) {
 	return div(argv, argc)
 }
 
-func ellVector(argv []LAny, argc int) (LAny, error) {
+func ellVector(argv []*LAny, argc int) (*LAny, error) {
 	return vector(argv...), nil
 }
 
-func ellToVector(argv []LAny, argc int) (LAny, error) {
+func ellToVector(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-vector", "1", argc)
 	}
 	return toVector(argv[0])
 }
 
-func ellMakeVector(argv []LAny, argc int) (LAny, error) {
+func ellMakeVector(argv []*LAny, argc int) (*LAny, error) {
 	if argc > 0 {
-		initVal := LAny(Null)
+		initVal := Null
 		vlen, err := intValue(argv[0])
 		if err != nil {
 			return nil, err
@@ -569,7 +551,7 @@ func ellMakeVector(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("make-vector", "1-2", argc)
 }
 
-func ellVectorP(argv []LAny, argc int) (LAny, error) {
+func ellVectorP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isVector(argv[0]) {
 			return True, nil
@@ -579,7 +561,7 @@ func ellVectorP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("vector?", "1", argc)
 }
 
-func ellVectorSetBang(argv []LAny, argc int) (LAny, error) {
+func ellVectorSetBang(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 3 {
 		a := argv[0]
 		idx, err := intValue(argv[1])
@@ -595,7 +577,7 @@ func ellVectorSetBang(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("vector-set!", "3", argc)
 }
 
-func ellVectorRef(argv []LAny, argc int) (LAny, error) {
+func ellVectorRef(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		a := argv[0]
 		idx, err := intValue(argv[1])
@@ -611,7 +593,7 @@ func ellVectorRef(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("vector-ref", "2", argc)
 }
 
-func ellGe(argv []LAny, argc int) (LAny, error) {
+func ellGe(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		b, err := greaterOrEqual(argv[0], argv[1])
 		if err != nil {
@@ -622,7 +604,7 @@ func ellGe(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError(">=", "2", argc)
 }
 
-func ellLe(argv []LAny, argc int) (LAny, error) {
+func ellLe(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		b, err := lessOrEqual(argv[0], argv[1])
 		if err != nil {
@@ -633,7 +615,7 @@ func ellLe(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("<=", "2", argc)
 }
 
-func ellGt(argv []LAny, argc int) (LAny, error) {
+func ellGt(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		b, err := greater(argv[0], argv[1])
 		if err != nil {
@@ -644,7 +626,7 @@ func ellGt(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError(">", "2", argc)
 }
 
-func ellLt(argv []LAny, argc int) (LAny, error) {
+func ellLt(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		b, err := less(argv[0], argv[1])
 		if err != nil {
@@ -655,7 +637,7 @@ func ellLt(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("<", "2", argc)
 }
 
-func ellZeroP(argv []LAny, argc int) (LAny, error) {
+func ellZeroP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		f, err := floatValue(argv[0])
 		if err != nil {
@@ -669,17 +651,17 @@ func ellZeroP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("zero?", "1", argc)
 }
 
-func ellNumberToString(argv []LAny, argc int) (LAny, error) {
+func ellNumberToString(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("number->string", "1", argc)
 	}
 	if !isNumber(argv[0]) {
 		return nil, ArgTypeError("number", 1, argv[0])
 	}
-	return LString(argv[0].String()), nil
+	return newString(argv[0].String()), nil
 }
 
-func ellStringLength(argv []LAny, argc int) (LAny, error) {
+func ellStringLength(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("string-length", "1", argc)
 	}
@@ -687,17 +669,17 @@ func ellStringLength(argv []LAny, argc int) (LAny, error) {
 		return nil, ArgTypeError("string", 1, argv[0])
 	}
 	i := length(argv[0])
-	return LNumber(int64(i)), nil
+	return newInt(i), nil
 }
 
-func ellLength(argv []LAny, argc int) (LAny, error) {
+func ellLength(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
-		return LNumber(int64(length(argv[0]))), nil
+		return newInt(length(argv[0])), nil
 	}
 	return nil, ArgcError("length", "1", argc)
 }
 
-func ellNot(argv []LAny, argc int) (LAny, error) {
+func ellNot(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if argv[0] == False {
 			return True, nil
@@ -707,7 +689,7 @@ func ellNot(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("not", "1", argc)
 }
 
-func ellNullP(argv []LAny, argc int) (LAny, error) {
+func ellNullP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if argv[0] == Null {
 			return True, nil
@@ -717,7 +699,7 @@ func ellNullP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("nil?", "1", argc)
 }
 
-func ellBooleanP(argv []LAny, argc int) (LAny, error) {
+func ellBooleanP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isBoolean(argv[0]) {
 			return True, nil
@@ -727,7 +709,7 @@ func ellBooleanP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("boolean?", "1", argc)
 }
 
-func elLSymbolP(argv []LAny, argc int) (LAny, error) {
+func elLSymbolP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isSymbol(argv[0]) {
 			return True, nil
@@ -737,14 +719,14 @@ func elLSymbolP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("symbol?", "1", argc)
 }
 
-func elLSymbol(argv []LAny, argc int) (LAny, error) {
+func elLSymbol(argv []*LAny, argc int) (*LAny, error) {
 	if argc < 1 {
 		return nil, ArgcError("symbol", "1+", argc)
 	}
 	return symbol(argv[:argc])
 }
 
-func ellKeywordP(argv []LAny, argc int) (LAny, error) {
+func ellKeywordP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isKeyword(argv[0]) {
 			return True, nil
@@ -754,7 +736,7 @@ func ellKeywordP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("keyword?", "1", argc)
 }
 
-func ellTypeP(argv []LAny, argc int) (LAny, error) {
+func ellTypeP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isType(argv[0]) {
 			return True, nil
@@ -764,7 +746,7 @@ func ellTypeP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("type?", "1", argc)
 }
 
-func ellTypeName(argv []LAny, argc int) (LAny, error) {
+func ellTypeName(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isType(argv[0]) {
 			return typeName(argv[0])
@@ -774,7 +756,7 @@ func ellTypeName(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("type-name", "1", argc)
 }
 
-func ellStringP(argv []LAny, argc int) (LAny, error) {
+func ellStringP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isString(argv[0]) {
 			return True, nil
@@ -784,9 +766,9 @@ func ellStringP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("string?", "1", argc)
 }
 
-func ellCharP(argv []LAny, argc int) (LAny, error) {
+func ellCharacterP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
-		if isChar(argv[0]) {
+		if isCharacter(argv[0]) {
 			return True, nil
 		}
 		return False, nil
@@ -794,7 +776,7 @@ func ellCharP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("character?", "1", argc)
 }
 
-func ellFunctionP(argv []LAny, argc int) (LAny, error) {
+func ellFunctionP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isFunction(argv[0]) || isKeyword(argv[0]) {
 			return True, nil
@@ -804,7 +786,7 @@ func ellFunctionP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("function?", "1", argc)
 }
 
-func ellListP(argv []LAny, argc int) (LAny, error) {
+func ellListP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isList(argv[0]) {
 			return True, nil
@@ -814,7 +796,7 @@ func ellListP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("list?", "1", argc)
 }
 
-func ellEmptyP(argv []LAny, argc int) (LAny, error) {
+func ellEmptyP(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("empty?", "1", argc)
 	}
@@ -824,15 +806,15 @@ func ellEmptyP(argv []LAny, argc int) (LAny, error) {
 	return False, nil
 }
 
-func ellString(argv []LAny, argc int) (LAny, error) {
+func ellString(argv []*LAny, argc int) (*LAny, error) {
 	s := ""
 	for i := 0; i < argc; i++ {
 		s += argv[i].String()
 	}
-	return LString(s), nil
+	return newString(s), nil
 }
 
-func ellCar(argv []LAny, argc int) (LAny, error) {
+func ellCar(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		//		return safeCar(argv[0])
 		return car(argv[0]), nil
@@ -840,7 +822,7 @@ func ellCar(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("car", "1", argc)
 }
 
-func ellCdr(argv []LAny, argc int) (LAny, error) {
+func ellCdr(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		//		return safeCdr(argv[0])
 		return cdr(argv[0]), nil
@@ -848,7 +830,7 @@ func ellCdr(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("cdr", "1", argc)
 }
 
-func ellSetCarBang(argv []LAny, argc int) (LAny, error) {
+func ellSetCarBang(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		err := setCar(argv[0], argv[1])
 		if err != nil {
@@ -859,7 +841,7 @@ func ellSetCarBang(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("set-car!", "2", argc)
 }
 
-func ellSetCdrBang(argv []LAny, argc int) (LAny, error) {
+func ellSetCdrBang(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
 		err := setCdr(argv[0], argv[1])
 		if err != nil {
@@ -870,7 +852,7 @@ func ellSetCdrBang(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("set-cdr!", "2", argc)
 }
 
-func ellCaar(argv []LAny, argc int) (LAny, error) {
+func ellCaar(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -881,7 +863,7 @@ func ellCaar(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("caar", "1", argc)
 }
 
-func ellCadr(argv []LAny, argc int) (LAny, error) {
+func ellCadr(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -892,7 +874,7 @@ func ellCadr(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("cadr", "1", argc)
 }
 
-func ellCddr(argv []LAny, argc int) (LAny, error) {
+func ellCddr(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -903,7 +885,7 @@ func ellCddr(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("cddr", "1", argc)
 }
 
-func ellCadar(argv []LAny, argc int) (LAny, error) {
+func ellCadar(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -914,7 +896,7 @@ func ellCadar(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("cadar", "1", argc)
 }
 
-func ellCaddr(argv []LAny, argc int) (LAny, error) {
+func ellCaddr(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -924,7 +906,7 @@ func ellCaddr(argv []LAny, argc int) (LAny, error) {
 	}
 	return nil, ArgcError("caddr", "1", argc)
 }
-func ellCdddr(argv []LAny, argc int) (LAny, error) {
+func ellCdddr(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -935,19 +917,18 @@ func ellCdddr(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("cdddr", "1", argc)
 }
 
-func ellCons(argv []LAny, argc int) (LAny, error) {
+func ellCons(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 2 {
-		switch lst := argv[1].(type) {
-		case *LList:
-			return cons(argv[0], lst), nil
-		default:
+		lst := argv[1]
+		if !isList(lst) {
 			return nil, ArgTypeError("list", 2, lst)
 		}
+		return cons(argv[0], lst), nil
 	}
 	return nil, ArgcError("cons", "2", argc)
 }
 
-func ellStructP(argv []LAny, argc int) (LAny, error) {
+func ellStructP(argv []*LAny, argc int) (*LAny, error) {
 	if argc == 1 {
 		if isStruct(argv[0]) {
 			return True, nil
@@ -957,14 +938,14 @@ func ellStructP(argv []LAny, argc int) (LAny, error) {
 	return nil, ArgcError("struct?", "1", argc)
 }
 
-func ellGet(argv []LAny, argc int) (LAny, error) {
+func ellGet(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 2 {
 		return nil, ArgcError("get", "2", argc)
 	}
 	return get(argv[0], argv[1])
 }
 
-func ellHasP(argv []LAny, argc int) (LAny, error) {
+func ellHasP(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 2 {
 		return nil, ArgcError("has?", "2", argc)
 	}
@@ -978,35 +959,37 @@ func ellHasP(argv []LAny, argc int) (LAny, error) {
 	return False, nil
 }
 
-func ellPutBang(argv []LAny, argc int) (LAny, error) {
+func ellPutBang(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 3 {
 		return nil, ArgcError("put!", "3", argc)
 	}
 	return put(argv[0], argv[1], argv[2])
 }
 
-func ellAssoc(argv []LAny, argc int) (LAny, error) {
+/*
+func ellAssoc(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 3 {
 		return nil, ArgcError("assoc", "3", argc)
 	}
 	return assoc(argv[0], argv[1], argv[2])
 }
 
-func ellDissoc(argv []LAny, argc int) (LAny, error) {
+func ellDissoc(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 3 {
 		return nil, ArgcError("dissoc", "2", argc)
 	}
 	return dissoc(argv[0], argv[1])
 }
+*/
 
-func ellToList(argv []LAny, argc int) (LAny, error) {
+func ellToList(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-list", "1", argc)
 	}
 	return toList(argv[0])
 }
 
-func ellJSON(argv []LAny, argc int) (LAny, error) {
+func ellJSON(argv []*LAny, argc int) (*LAny, error) {
 	if argc != 1 {
 		return nil, ArgcError("json", "1", argc)
 	}
@@ -1014,5 +997,5 @@ func ellJSON(argv []LAny, argc int) (LAny, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LString(s), nil
+	return newString(s), nil
 }

--- a/ell.go
+++ b/ell.go
@@ -47,13 +47,13 @@ func initEnvironment() {
 	defineFunction("macroexpand", ellMacroexpand, "(<any>) <any>")
 	defineFunction("compile", ellCompile, "(<any>) <code>")
 
-	defineFunction("type", ellType, "(<any>) <type>")
+	defineFunction("type", elvariant, "(<any>) <type>")
 	defineFunction("value", ellValue, "<any>) <any>")
 	defineFunction("instance", ellInstance, "(<type> <any>) <any>")
 	defineFunction("normalize-keyword-args", ellNormalizeKeywordArgs, "(<list> <keyword>+) <list>")
 
-	defineFunction("type?", ellTypeP, "(<any>) <boolean>")
-	defineFunction("type-name", ellTypeName, "(<type>) <symbol>")
+	defineFunction("type?", elvariantP, "(<any>) <boolean>")
+	defineFunction("type-name", elvariantName, "(<type>) <symbol>")
 
 	defineFunction("struct", ellStruct, "(<any>+) <struct>")
 	defineFunction("equal?", ellEq, "(<any> <any>) <boolean>")
@@ -141,29 +141,29 @@ func initEnvironment() {
 //expanders - these only gets called from the macro expander itself, so we know the single arg is an *LList
 //
 
-func ellLetrec(argv []*LAny, argc int) (*LAny, error) {
+func ellLetrec(argv []*LOB, argc int) (*LOB, error) {
 	return expandLetrec(argv[0])
 }
 
-func ellLet(argv []*LAny, argc int) (*LAny, error) {
+func ellLet(argv []*LOB, argc int) (*LOB, error) {
 	return expandLet(argv[0])
 }
 
-func ellCond(argv []*LAny, argc int) (*LAny, error) {
+func ellCond(argv []*LOB, argc int) (*LOB, error) {
 	return expandCond(argv[0])
 }
 
-func ellQuasiquote(argv []*LAny, argc int) (*LAny, error) {
+func ellQuasiquote(argv []*LOB, argc int) (*LOB, error) {
 	return expandQuasiquote(argv[0])
 }
 
 // functions
 
-func ellVersion(argv []*LAny, argc int) (*LAny, error) {
+func ellVersion(argv []*LOB, argc int) (*LOB, error) {
 	return newString(Version), nil
 }
 
-func ellDefinedP(argv []*LAny, argc int) (*LAny, error) {
+func ellDefinedP(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("defined?", "1", argc)
 	}
@@ -176,7 +176,7 @@ func ellDefinedP(argv []*LAny, argc int) (*LAny, error) {
 	return False, nil
 }
 
-func ellFileContents(argv []*LAny, argc int) (*LAny, error) {
+func ellFileContents(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("file-contents", "1", argc)
 	}
@@ -194,7 +194,7 @@ func ellFileContents(argv []*LAny, argc int) (*LAny, error) {
 	return newString(s), nil
 }
 
-func ellOpenInputString(argv []*LAny, argc int) (*LAny, error) {
+func ellOpenInputString(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("open-input-string", "1", argc)
 	}
@@ -205,7 +205,7 @@ func ellOpenInputString(argv []*LAny, argc int) (*LAny, error) {
 	return openInputString(s), nil
 }
 
-func ellOpenInputFile(argv []*LAny, argc int) (*LAny, error) {
+func ellOpenInputFile(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("open-input-file", "1", argc)
 	}
@@ -216,27 +216,27 @@ func ellOpenInputFile(argv []*LAny, argc int) (*LAny, error) {
 	return openInputFile(s)
 }
 
-func ellRead(argv []*LAny, argc int) (*LAny, error) {
+func ellRead(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("read", "1", argc)
 	}
 	return readInputPort(argv[0])
 }
-func ellCloseInput(argv []*LAny, argc int) (*LAny, error) {
+func ellCloseInput(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("read", "1", argc)
 	}
 	return nil, closeInputPort(argv[0])
 }
 
-func ellMacroexpand(argv []*LAny, argc int) (*LAny, error) {
+func ellMacroexpand(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("macroexpand", "1", argc)
 	}
 	return macroexpand(argv[0])
 }
 
-func ellCompile(argv []*LAny, argc int) (*LAny, error) {
+func ellCompile(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("compile", "1", argc)
 	}
@@ -247,28 +247,28 @@ func ellCompile(argv []*LAny, argc int) (*LAny, error) {
 	return compile(expanded)
 }
 
-func ellType(argv []*LAny, argc int) (*LAny, error) {
+func elvariant(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("type", "1", argc)
 	}
-	return argv[0].ltype, nil
+	return argv[0].variant, nil
 }
 
-func ellValue(argv []*LAny, argc int) (*LAny, error) {
+func ellValue(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("value", "1", argc)
 	}
 	return value(argv[0]), nil
 }
 
-func ellInstance(argv []*LAny, argc int) (*LAny, error) {
+func ellInstance(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 2 {
 		return nil, ArgcError("instance", "2", argc)
 	}
 	return instance(argv[0], argv[1])
 }
 
-func ellNormalizeKeywordArgs(argv []*LAny, argc int) (*LAny, error) {
+func ellNormalizeKeywordArgs(argv []*LOB, argc int) (*LOB, error) {
 	//(normalize-keyword-args '(x: 23) x: y:) -> (x:)
 	//(normalize-keyword-args '(x: 23 z: 100) x: y:) -> error("bad keyword z: in argument list")
 	if argc < 1 {
@@ -280,11 +280,11 @@ func ellNormalizeKeywordArgs(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgTypeError("list", 1, argv[0])
 }
 
-func ellStruct(argv []*LAny, argc int) (*LAny, error) {
+func ellStruct(argv []*LOB, argc int) (*LOB, error) {
 	return newStruct(argv[:argc])
 }
 
-func ellIdenticalP(argv []*LAny, argc int) (*LAny, error) {
+func ellIdenticalP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		b := identical(argv[0], argv[1])
 		if b {
@@ -295,7 +295,7 @@ func ellIdenticalP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("identical?", "2", argc)
 }
 
-func ellEq(argv []*LAny, argc int) (*LAny, error) {
+func ellEq(argv []*LOB, argc int) (*LOB, error) {
 	if argc < 1 {
 		return nil, ArgcError("eq?", "1+", argc)
 	}
@@ -308,7 +308,7 @@ func ellEq(argv []*LAny, argc int) (*LAny, error) {
 	return True, nil
 }
 
-func ellNumeq(argv []*LAny, argc int) (*LAny, error) {
+func ellNumeq(argv []*LOB, argc int) (*LOB, error) {
 	if argc < 1 {
 		return nil, ArgcError("=", "1+", argc)
 	}
@@ -321,7 +321,7 @@ func ellNumeq(argv []*LAny, argc int) (*LAny, error) {
 	return True, nil
 }
 
-func ellDisplay(argv []*LAny, argc int) (*LAny, error) {
+func ellDisplay(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("display", "1", argc)
@@ -330,7 +330,7 @@ func ellDisplay(argv []*LAny, argc int) (*LAny, error) {
 	return Null, nil
 }
 
-func ellWrite(argv []*LAny, argc int) (*LAny, error) {
+func ellWrite(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("write", "1", argc)
@@ -339,7 +339,7 @@ func ellWrite(argv []*LAny, argc int) (*LAny, error) {
 	return Null, nil
 }
 
-func ellNewline(argv []*LAny, argc int) (*LAny, error) {
+func ellNewline(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 0 {
 		//todo: add the optional output argument like scheme
 		return nil, ArgcError("newline", "0", argc)
@@ -348,7 +348,7 @@ func ellNewline(argv []*LAny, argc int) (*LAny, error) {
 	return Null, nil
 }
 
-func ellFatal(argv []*LAny, argc int) (*LAny, error) {
+func ellFatal(argv []*LOB, argc int) (*LOB, error) {
 	s := ""
 	for _, o := range argv {
 		s += fmt.Sprintf("%v", o)
@@ -356,7 +356,7 @@ func ellFatal(argv []*LAny, argc int) (*LAny, error) {
 	return nil, Error(s)
 }
 
-func ellToString(argv []*LAny, argc int) (*LAny, error) {
+func ellToString(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-string", "1", argc)
 	}
@@ -364,20 +364,20 @@ func ellToString(argv []*LAny, argc int) (*LAny, error) {
 	return newString(s), nil
 }
 
-func ellPrint(argv []*LAny, argc int) (*LAny, error) {
+func ellPrint(argv []*LOB, argc int) (*LOB, error) {
 	for _, o := range argv {
 		fmt.Printf("%v", o)
 	}
 	return Null, nil
 }
 
-func ellPrintln(argv []*LAny, argc int) (*LAny, error) {
+func ellPrintln(argv []*LOB, argc int) (*LOB, error) {
 	ellPrint(argv, argc)
 	fmt.Println("")
 	return Null, nil
 }
 
-func ellConcat(argv []*LAny, argc int) (*LAny, error) {
+func ellConcat(argv []*LOB, argc int) (*LOB, error) {
 	result := EmptyList
 	tail := result
 	for i := 0; i < argc; i++ {
@@ -399,7 +399,7 @@ func ellConcat(argv []*LAny, argc int) (*LAny, error) {
 	return result, nil
 }
 
-func ellReverse(argv []*LAny, argc int) (*LAny, error) {
+func ellReverse(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("reverse", "1", argc)
 	}
@@ -410,12 +410,12 @@ func ellReverse(argv []*LAny, argc int) (*LAny, error) {
 	return reverse(lst), nil
 }
 
-func ellFlatten(argv []*LAny, argc int) (*LAny, error) {
+func ellFlatten(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("flatten", "1", argc)
 	}
 	seq := argv[0]
-	switch seq.ltype {
+	switch seq.variant {
 	case typeList:
 		return flatten(seq), nil
 	case typeVector:
@@ -426,7 +426,7 @@ func ellFlatten(argv []*LAny, argc int) (*LAny, error) {
 	}
 }
 
-func ellList(argv []*LAny, argc int) (*LAny, error) {
+func ellList(argv []*LOB, argc int) (*LOB, error) {
 	p := EmptyList
 	for i := argc - 1; i >= 0; i-- {
 		p = cons(argv[i], p)
@@ -434,7 +434,7 @@ func ellList(argv []*LAny, argc int) (*LAny, error) {
 	return p, nil
 }
 
-func ellNumberP(argv []*LAny, argc int) (*LAny, error) {
+func ellNumberP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isNumber(argv[0]) {
 			return True, nil
@@ -444,7 +444,7 @@ func ellNumberP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("number?", "1", argc)
 }
 
-func ellIntP(argv []*LAny, argc int) (*LAny, error) {
+func ellIntP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isInt(argv[0]) {
 			return True, nil
@@ -454,7 +454,7 @@ func ellIntP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("int?", "1", argc)
 }
 
-func ellFloatP(argv []*LAny, argc int) (*LAny, error) {
+func ellFloatP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isFloat(argv[0]) {
 			return True, nil
@@ -464,7 +464,7 @@ func ellFloatP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("float?", "1", argc)
 }
 
-func ellQuotient(argv []*LAny, argc int) (*LAny, error) {
+func ellQuotient(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		n1, err := int64Value(argv[0])
 		if err != nil {
@@ -482,7 +482,7 @@ func ellQuotient(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("quotient", "2", argc)
 }
 
-func ellRemainder(argv []*LAny, argc int) (*LAny, error) {
+func ellRemainder(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		n1, err := int64Value(argv[0])
 		if err != nil {
@@ -500,40 +500,40 @@ func ellRemainder(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("remainder", "2", argc)
 }
 
-func ellPlus(argv []*LAny, argc int) (*LAny, error) {
+func ellPlus(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		return add(argv[0], argv[1])
 	}
 	return sum(argv, argc)
 }
 
-func ellMinus(argv []*LAny, argc int) (*LAny, error) {
+func ellMinus(argv []*LOB, argc int) (*LOB, error) {
 	return minus(argv, argc)
 }
 
-func ellTimes(argv []*LAny, argc int) (*LAny, error) {
+func ellTimes(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		return mul(argv[0], argv[1])
 	}
 	return product(argv, argc)
 }
 
-func ellDiv(argv []*LAny, argc int) (*LAny, error) {
+func ellDiv(argv []*LOB, argc int) (*LOB, error) {
 	return div(argv, argc)
 }
 
-func ellVector(argv []*LAny, argc int) (*LAny, error) {
+func ellVector(argv []*LOB, argc int) (*LOB, error) {
 	return vector(argv...), nil
 }
 
-func ellToVector(argv []*LAny, argc int) (*LAny, error) {
+func ellToVector(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-vector", "1", argc)
 	}
 	return toVector(argv[0])
 }
 
-func ellMakeVector(argv []*LAny, argc int) (*LAny, error) {
+func ellMakeVector(argv []*LOB, argc int) (*LOB, error) {
 	if argc > 0 {
 		initVal := Null
 		vlen, err := intValue(argv[0])
@@ -551,7 +551,7 @@ func ellMakeVector(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("make-vector", "1-2", argc)
 }
 
-func ellVectorP(argv []*LAny, argc int) (*LAny, error) {
+func ellVectorP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isVector(argv[0]) {
 			return True, nil
@@ -561,7 +561,7 @@ func ellVectorP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("vector?", "1", argc)
 }
 
-func ellVectorSetBang(argv []*LAny, argc int) (*LAny, error) {
+func ellVectorSetBang(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 3 {
 		a := argv[0]
 		idx, err := intValue(argv[1])
@@ -577,7 +577,7 @@ func ellVectorSetBang(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("vector-set!", "3", argc)
 }
 
-func ellVectorRef(argv []*LAny, argc int) (*LAny, error) {
+func ellVectorRef(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		a := argv[0]
 		idx, err := intValue(argv[1])
@@ -593,7 +593,7 @@ func ellVectorRef(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("vector-ref", "2", argc)
 }
 
-func ellGe(argv []*LAny, argc int) (*LAny, error) {
+func ellGe(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		b, err := greaterOrEqual(argv[0], argv[1])
 		if err != nil {
@@ -604,7 +604,7 @@ func ellGe(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError(">=", "2", argc)
 }
 
-func ellLe(argv []*LAny, argc int) (*LAny, error) {
+func ellLe(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		b, err := lessOrEqual(argv[0], argv[1])
 		if err != nil {
@@ -615,7 +615,7 @@ func ellLe(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("<=", "2", argc)
 }
 
-func ellGt(argv []*LAny, argc int) (*LAny, error) {
+func ellGt(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		b, err := greater(argv[0], argv[1])
 		if err != nil {
@@ -626,7 +626,7 @@ func ellGt(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError(">", "2", argc)
 }
 
-func ellLt(argv []*LAny, argc int) (*LAny, error) {
+func ellLt(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		b, err := less(argv[0], argv[1])
 		if err != nil {
@@ -637,7 +637,7 @@ func ellLt(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("<", "2", argc)
 }
 
-func ellZeroP(argv []*LAny, argc int) (*LAny, error) {
+func ellZeroP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		f, err := floatValue(argv[0])
 		if err != nil {
@@ -651,7 +651,7 @@ func ellZeroP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("zero?", "1", argc)
 }
 
-func ellNumberToString(argv []*LAny, argc int) (*LAny, error) {
+func ellNumberToString(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("number->string", "1", argc)
 	}
@@ -661,7 +661,7 @@ func ellNumberToString(argv []*LAny, argc int) (*LAny, error) {
 	return newString(argv[0].String()), nil
 }
 
-func ellStringLength(argv []*LAny, argc int) (*LAny, error) {
+func ellStringLength(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("string-length", "1", argc)
 	}
@@ -672,14 +672,14 @@ func ellStringLength(argv []*LAny, argc int) (*LAny, error) {
 	return newInt(i), nil
 }
 
-func ellLength(argv []*LAny, argc int) (*LAny, error) {
+func ellLength(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		return newInt(length(argv[0])), nil
 	}
 	return nil, ArgcError("length", "1", argc)
 }
 
-func ellNot(argv []*LAny, argc int) (*LAny, error) {
+func ellNot(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if argv[0] == False {
 			return True, nil
@@ -689,7 +689,7 @@ func ellNot(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("not", "1", argc)
 }
 
-func ellNullP(argv []*LAny, argc int) (*LAny, error) {
+func ellNullP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if argv[0] == Null {
 			return True, nil
@@ -699,7 +699,7 @@ func ellNullP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("nil?", "1", argc)
 }
 
-func ellBooleanP(argv []*LAny, argc int) (*LAny, error) {
+func ellBooleanP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isBoolean(argv[0]) {
 			return True, nil
@@ -709,7 +709,7 @@ func ellBooleanP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("boolean?", "1", argc)
 }
 
-func elLSymbolP(argv []*LAny, argc int) (*LAny, error) {
+func elLSymbolP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isSymbol(argv[0]) {
 			return True, nil
@@ -719,14 +719,14 @@ func elLSymbolP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("symbol?", "1", argc)
 }
 
-func elLSymbol(argv []*LAny, argc int) (*LAny, error) {
+func elLSymbol(argv []*LOB, argc int) (*LOB, error) {
 	if argc < 1 {
 		return nil, ArgcError("symbol", "1+", argc)
 	}
 	return symbol(argv[:argc])
 }
 
-func ellKeywordP(argv []*LAny, argc int) (*LAny, error) {
+func ellKeywordP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isKeyword(argv[0]) {
 			return True, nil
@@ -736,7 +736,7 @@ func ellKeywordP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("keyword?", "1", argc)
 }
 
-func ellTypeP(argv []*LAny, argc int) (*LAny, error) {
+func elvariantP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isType(argv[0]) {
 			return True, nil
@@ -746,7 +746,7 @@ func ellTypeP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("type?", "1", argc)
 }
 
-func ellTypeName(argv []*LAny, argc int) (*LAny, error) {
+func elvariantName(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isType(argv[0]) {
 			return typeName(argv[0])
@@ -756,7 +756,7 @@ func ellTypeName(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("type-name", "1", argc)
 }
 
-func ellStringP(argv []*LAny, argc int) (*LAny, error) {
+func ellStringP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isString(argv[0]) {
 			return True, nil
@@ -766,7 +766,7 @@ func ellStringP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("string?", "1", argc)
 }
 
-func ellCharacterP(argv []*LAny, argc int) (*LAny, error) {
+func ellCharacterP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isCharacter(argv[0]) {
 			return True, nil
@@ -776,7 +776,7 @@ func ellCharacterP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("character?", "1", argc)
 }
 
-func ellFunctionP(argv []*LAny, argc int) (*LAny, error) {
+func ellFunctionP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isFunction(argv[0]) || isKeyword(argv[0]) {
 			return True, nil
@@ -786,7 +786,7 @@ func ellFunctionP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("function?", "1", argc)
 }
 
-func ellListP(argv []*LAny, argc int) (*LAny, error) {
+func ellListP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isList(argv[0]) {
 			return True, nil
@@ -796,7 +796,7 @@ func ellListP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("list?", "1", argc)
 }
 
-func ellEmptyP(argv []*LAny, argc int) (*LAny, error) {
+func ellEmptyP(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("empty?", "1", argc)
 	}
@@ -806,7 +806,7 @@ func ellEmptyP(argv []*LAny, argc int) (*LAny, error) {
 	return False, nil
 }
 
-func ellString(argv []*LAny, argc int) (*LAny, error) {
+func ellString(argv []*LOB, argc int) (*LOB, error) {
 	s := ""
 	for i := 0; i < argc; i++ {
 		s += argv[i].String()
@@ -814,7 +814,7 @@ func ellString(argv []*LAny, argc int) (*LAny, error) {
 	return newString(s), nil
 }
 
-func ellCar(argv []*LAny, argc int) (*LAny, error) {
+func ellCar(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		//		return safeCar(argv[0])
 		return car(argv[0]), nil
@@ -822,7 +822,7 @@ func ellCar(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("car", "1", argc)
 }
 
-func ellCdr(argv []*LAny, argc int) (*LAny, error) {
+func ellCdr(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		//		return safeCdr(argv[0])
 		return cdr(argv[0]), nil
@@ -830,7 +830,7 @@ func ellCdr(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cdr", "1", argc)
 }
 
-func ellSetCarBang(argv []*LAny, argc int) (*LAny, error) {
+func ellSetCarBang(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		err := setCar(argv[0], argv[1])
 		if err != nil {
@@ -841,7 +841,7 @@ func ellSetCarBang(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("set-car!", "2", argc)
 }
 
-func ellSetCdrBang(argv []*LAny, argc int) (*LAny, error) {
+func ellSetCdrBang(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		err := setCdr(argv[0], argv[1])
 		if err != nil {
@@ -852,7 +852,7 @@ func ellSetCdrBang(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("set-cdr!", "2", argc)
 }
 
-func ellCaar(argv []*LAny, argc int) (*LAny, error) {
+func ellCaar(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -863,7 +863,7 @@ func ellCaar(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("caar", "1", argc)
 }
 
-func ellCadr(argv []*LAny, argc int) (*LAny, error) {
+func ellCadr(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -874,7 +874,7 @@ func ellCadr(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cadr", "1", argc)
 }
 
-func ellCddr(argv []*LAny, argc int) (*LAny, error) {
+func ellCddr(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -885,7 +885,7 @@ func ellCddr(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cddr", "1", argc)
 }
 
-func ellCadar(argv []*LAny, argc int) (*LAny, error) {
+func ellCadar(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -896,7 +896,7 @@ func ellCadar(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cadar", "1", argc)
 }
 
-func ellCaddr(argv []*LAny, argc int) (*LAny, error) {
+func ellCaddr(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -906,7 +906,7 @@ func ellCaddr(argv []*LAny, argc int) (*LAny, error) {
 	}
 	return nil, ArgcError("caddr", "1", argc)
 }
-func ellCdddr(argv []*LAny, argc int) (*LAny, error) {
+func ellCdddr(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		lst := argv[0]
 		if isList(lst) {
@@ -917,7 +917,7 @@ func ellCdddr(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cdddr", "1", argc)
 }
 
-func ellCons(argv []*LAny, argc int) (*LAny, error) {
+func ellCons(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 2 {
 		lst := argv[1]
 		if !isList(lst) {
@@ -928,7 +928,7 @@ func ellCons(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("cons", "2", argc)
 }
 
-func ellStructP(argv []*LAny, argc int) (*LAny, error) {
+func ellStructP(argv []*LOB, argc int) (*LOB, error) {
 	if argc == 1 {
 		if isStruct(argv[0]) {
 			return True, nil
@@ -938,14 +938,14 @@ func ellStructP(argv []*LAny, argc int) (*LAny, error) {
 	return nil, ArgcError("struct?", "1", argc)
 }
 
-func ellGet(argv []*LAny, argc int) (*LAny, error) {
+func ellGet(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 2 {
 		return nil, ArgcError("get", "2", argc)
 	}
 	return get(argv[0], argv[1])
 }
 
-func ellHasP(argv []*LAny, argc int) (*LAny, error) {
+func ellHasP(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 2 {
 		return nil, ArgcError("has?", "2", argc)
 	}
@@ -959,7 +959,7 @@ func ellHasP(argv []*LAny, argc int) (*LAny, error) {
 	return False, nil
 }
 
-func ellPutBang(argv []*LAny, argc int) (*LAny, error) {
+func ellPutBang(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 3 {
 		return nil, ArgcError("put!", "3", argc)
 	}
@@ -967,14 +967,14 @@ func ellPutBang(argv []*LAny, argc int) (*LAny, error) {
 }
 
 /*
-func ellAssoc(argv []*LAny, argc int) (*LAny, error) {
+func ellAssoc(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 3 {
 		return nil, ArgcError("assoc", "3", argc)
 	}
 	return assoc(argv[0], argv[1], argv[2])
 }
 
-func ellDissoc(argv []*LAny, argc int) (*LAny, error) {
+func ellDissoc(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 3 {
 		return nil, ArgcError("dissoc", "2", argc)
 	}
@@ -982,14 +982,14 @@ func ellDissoc(argv []*LAny, argc int) (*LAny, error) {
 }
 */
 
-func ellToList(argv []*LAny, argc int) (*LAny, error) {
+func ellToList(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("to-list", "1", argc)
 	}
 	return toList(argv[0])
 }
 
-func ellJSON(argv []*LAny, argc int) (*LAny, error) {
+func ellJSON(argv []*LOB, argc int) (*LOB, error) {
 	if argc != 1 {
 		return nil, ArgcError("json", "1", argc)
 	}

--- a/gell_test.go
+++ b/gell_test.go
@@ -19,42 +19,39 @@ import (
 	"testing"
 )
 
-func testType(t *testing.T, name string, sym lob) {
-	if !isSymbol(sym) {
-		t.Error("nil type is not a symbol:", sym)
-	}
+func testType(t *testing.T, name string, sym *LOB) {
 	if sym != intern(name) {
 		t.Error("type is not ", name, ":", sym)
 	}
 }
 
-func testIdentical(t *testing.T, o1 lob, o2 lob) {
+func testIdentical(t *testing.T, o1 *LOB, o2 *LOB) {
 	if o1 != o2 {
 		t.Error("objects should be identical but are not:", o1, "and", o2)
 	}
 }
-func testNotIdentical(t *testing.T, o1 lob, o2 lob) {
+func testNotIdentical(t *testing.T, o1 *LOB, o2 *LOB) {
 	if o1 == o2 {
 		t.Error("objects should not be identical but are:", o1, "and", o2)
 	}
 }
 
-func TestNil(t *testing.T) {
-	n1 := Nil
-	testIdentical(t, n1, Nil)
-	testNotIdentical(t, Nil, nil)
-	testType(t, "null", Nil.typeSymbol())
-	if n1 != Nil {
-		t.Error("nil isn't")
+func TestNull(t *testing.T) {
+	n1 := Null
+	testIdentical(t, n1, Null)
+	testNotIdentical(t, Null, nil)
+	testType(t, "<null>", Null.variant)
+	if n1 != Null {
+		t.Error("nil isn't Null")
 	}
 }
 
 func TestBooleans(t *testing.T) {
 	b1 := True
 	b2 := False
-	testType(t, "boolean", True.typeSymbol())
-	testType(t, "boolean", False.typeSymbol())
-	testIdentical(t, True.typeSymbol(), False.typeSymbol())
+	testType(t, "<boolean>", True.variant)
+	testType(t, "<boolean>", False.variant)
+	testIdentical(t, True.variant, False.variant)
 	testIdentical(t, b1, True)
 	testIdentical(t, b2, False)
 	testNotIdentical(t, b1, b2)

--- a/generic.go
+++ b/generic.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package main
 
-func isEmpty(obj *LAny) bool {
+func isEmpty(obj *LOB) bool {
 	seq := value(obj)
-	switch seq.ltype {
+	switch seq.variant {
 	case typeList:
 		return seq == EmptyList
 	case typeString:
@@ -34,9 +34,9 @@ func isEmpty(obj *LAny) bool {
 	}
 }
 
-func length(obj *LAny) int {
+func length(obj *LOB) int {
 	seq := value(obj)
-	switch seq.ltype {
+	switch seq.variant {
 	case typeString:
 		return len(seq.text)
 	case typeVector:
@@ -51,8 +51,8 @@ func length(obj *LAny) int {
 }
 
 /*
-func assoc(seq *LAny, key *LAny, val *LAny) (*LAny, error) {
-	switch seq.ltype {
+func assoc(seq *LOB, key *LOB, val *LOB) (*LOB, error) {
+	switch seq.variant {
 	case typeStruct:
 		s := copyStruct(seq)
 		s.bindings[key] = val
@@ -69,8 +69,8 @@ func assoc(seq *LAny, key *LAny, val *LAny) (*LAny, error) {
 	}
 }
 
-func dissoc(seq *LAny, key *LAny) (*LAny, error) {
-	switch seq.ltype {
+func dissoc(seq *LOB, key *LOB) (*LOB, error) {
+	switch seq.variant {
 	case typeStruct:
 		s := copyStruct(seq)
 		delete(s.bindings, key)
@@ -81,7 +81,7 @@ func dissoc(seq *LAny, key *LAny) (*LAny, error) {
 }
 */
 
-func reverse(lst *LAny) *LAny {
+func reverse(lst *LOB) *LOB {
 	rev := EmptyList
 	for lst != EmptyList {
 		rev = cons(lst.car, rev)
@@ -90,12 +90,12 @@ func reverse(lst *LAny) *LAny {
 	return rev
 }
 
-func flatten(lst *LAny) *LAny {
+func flatten(lst *LOB) *LOB {
 	result := EmptyList
 	tail := EmptyList
 	for lst != EmptyList {
 		item := lst.car
-		switch item.ltype {
+		switch item.variant {
 		case typeList:
 			item = flatten(item)
 		case typeVector:
@@ -118,7 +118,7 @@ func flatten(lst *LAny) *LAny {
 	return result
 }
 
-func concat(seq1 *LAny, seq2 *LAny) (*LAny, error) {
+func concat(seq1 *LOB, seq2 *LOB) (*LOB, error) {
 	rev := reverse(seq1)
 	if rev == EmptyList {
 		return seq2, nil

--- a/generic.go
+++ b/generic.go
@@ -16,31 +16,51 @@ limitations under the License.
 
 package main
 
-func length(seq LAny) int {
-	switch v := seq.Value().(type) {
-	case LString:
-		return len(v)
-	case *LVector:
-		return len(v.elements)
-	case *LList:
-		return listLength(v)
-	case *LStruct:
-		return len(v.bindings)
+func isEmpty(obj *LAny) bool {
+	seq := value(obj)
+	switch seq.ltype {
+	case typeList:
+		return seq == EmptyList
+	case typeString:
+		return len(seq.text) == 0
+	case typeVector:
+		return len(seq.elements) == 0
+	case typeStruct:
+		return len(seq.elements) == 0
+	case typeNull: //?
+		return true
+	default:
+		return false
+	}
+}
+
+func length(obj *LAny) int {
+	seq := value(obj)
+	switch seq.ltype {
+	case typeString:
+		return len(seq.text)
+	case typeVector:
+		return len(seq.elements)
+	case typeList:
+		return listLength(seq)
+	case typeStruct:
+		return len(seq.elements) / 2
 	default:
 		return -1
 	}
 }
 
-func assoc(seq LAny, key LAny, val LAny) (LAny, error) {
-	switch s := seq.(type) {
-	case *LStruct:
-		s2 := copyStruct(s)
-		s2.bindings[key] = val
-		return s2, nil
-	case *LVector:
-		if idx, ok := key.(LNumber); ok {
-			a := copyVector(s)
-			a.elements[int(idx)] = val
+/*
+func assoc(seq *LAny, key *LAny, val *LAny) (*LAny, error) {
+	switch seq.ltype {
+	case typeStruct:
+		s := copyStruct(seq)
+		s.bindings[key] = val
+		return s, nil
+	case typeVector:
+		if isNumber(key) {
+			a := copyVector(seq)
+			a.elements[int(seq.ival)] = val
 			return a, nil
 		}
 		return nil, TypeError(typeNumber, key)
@@ -49,18 +69,19 @@ func assoc(seq LAny, key LAny, val LAny) (LAny, error) {
 	}
 }
 
-func dissoc(seq LAny, key LAny) (LAny, error) {
-	switch s := seq.(type) {
-	case *LStruct:
-		s2 := copyStruct(s)
-		delete(s2.bindings, key)
-		return s2, nil
+func dissoc(seq *LAny, key *LAny) (*LAny, error) {
+	switch seq.ltype {
+	case typeStruct:
+		s := copyStruct(seq)
+		delete(s.bindings, key)
+		return s, nil
 	default:
 		return nil, Error("Cannot dissoc with this value: ", seq)
 	}
 }
+*/
 
-func reverse(lst *LList) *LList {
+func reverse(lst *LAny) *LAny {
 	rev := EmptyList
 	for lst != EmptyList {
 		rev = cons(lst.car, rev)
@@ -69,26 +90,25 @@ func reverse(lst *LList) *LList {
 	return rev
 }
 
-func flatten(lst *LList) *LList {
+func flatten(lst *LAny) *LAny {
 	result := EmptyList
 	tail := EmptyList
 	for lst != EmptyList {
 		item := lst.car
-		var fitem *LList
-		switch titem := item.(type) {
-		case *LList:
-			fitem = flatten(titem)
-		case *LVector:
-			litem, _ := toList(titem)
-			fitem = flatten(litem.(*LList))
+		switch item.ltype {
+		case typeList:
+			item = flatten(item)
+		case typeVector:
+			litem, _ := toList(item)
+			item = flatten(litem)
 		default:
-			fitem = list(item)
+			item = list(item)
 		}
 		if tail == EmptyList {
-			result = fitem
+			result = item
 			tail = result
 		} else {
-			tail.cdr = fitem
+			tail.cdr = item
 		}
 		for tail.cdr != EmptyList {
 			tail = tail.cdr
@@ -98,7 +118,7 @@ func flatten(lst *LList) *LList {
 	return result
 }
 
-func concat(seq1 *LList, seq2 *LList) (*LList, error) {
+func concat(seq1 *LAny, seq2 *LAny) (*LAny, error) {
 	rev := reverse(seq1)
 	if rev == EmptyList {
 		return seq2, nil

--- a/lib/ell.ell
+++ b/lib/ell.ell
@@ -146,9 +146,10 @@
              (and (struct? o) ((fn ~args ~@predicate-body) (value: o)) true))
        (defn ~sym ~args
          (if (not ~@predicate-body)
-             (error ~(string "not a valid " typesym ": ") (write-to-string ~arg)))
+             (error ~(string "not a valid " typesym ": ") (to-string ~arg)))
          (instance ~typesym ~(car args)))
        ~typesym)))
+
 
 ;;
 ;; generic functions dispatch to methods based on argument type

--- a/list.go
+++ b/list.go
@@ -35,7 +35,11 @@ func cons(car *LAny, cdr *LAny) *LAny {
 	if inExec {
 		conses++
 	}
-	return &LAny{ltype: typeList, car: car, cdr: cdr}
+	result := new(LAny)
+	result.ltype = typeList
+	result.car = car
+	result.cdr = cdr
+	return result
 }
 
 func safeCar(lst *LAny) (*LAny, error) {
@@ -217,7 +221,10 @@ func listToVector(lst *LAny) *LAny {
 		elems = append(elems, lst.car)
 		lst = lst.cdr
 	}
-	return &LAny{ltype: typeVector, elements: elems}
+	vec := new(LAny)
+	vec.ltype = typeVector
+	vec.elements = elems
+	return vec
 }
 
 func toList(obj *LAny) (*LAny, error) {

--- a/macro.go
+++ b/macro.go
@@ -79,9 +79,9 @@ func macroexpandList(expr *LAny) (*LAny, error) {
 func (mac *macro) expand(expr *LAny) (*LAny, error) {
 	expander := mac.expander
 	if expander.ltype == typeFunction {
-		if expander.function.closure != nil {
-			if expander.function.closure.code.argc == 1 {
-				expanded, err := exec(expander.function.closure.code, expr)
+		if expander.function.code != nil {
+			if expander.function.code.argc == 1 {
+				expanded, err := exec(expander.function.code, expr)
 				if err == nil {
 					if isList(expanded) {
 						return macroexpandObject(expanded)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ var verbose bool
 var interactive bool
 
 // Version - this version of gell
-const Version = "gell v0.1"
+const Version = "gell v0.2"
 
 // EllPath is the path where the library *.ell files can be found
 var EllPath string

--- a/module.go
+++ b/module.go
@@ -21,11 +21,11 @@ import (
 	"strings"
 )
 
-var constantsMap = make(map[LAny]int, 0)
-var constants = make([]LAny, 0, 1000)
+var constantsMap = make(map[*LAny]int, 0)
+var constants = make([]*LAny, 0, 1000)
 var globals = make([]*binding, 0, 1000)
-var globalsMap = make(map[*LSymbol]int, 0)
-var macroMap = make(map[LAny]*macro, 0)
+var globalsMap = make(map[*LAny]int, 0)
+var macroMap = make(map[*LAny]*macro, 0)
 var primitives = make([]*LPrimitive, 0, 1000)
 
 func checkInterrupt() bool {
@@ -40,7 +40,7 @@ func checkInterrupt() bool {
 	return false
 }
 
-func define(name string, obj LAny) {
+func define(name string, obj *LAny) {
 	sym := intern(name)
 	if sym == nil {
 		panic("Cannot define a value for this symbol: " + name)
@@ -69,9 +69,9 @@ func defineMacro(name string, fun primitive) {
 	defMacro(sym, prim)
 }
 
-func getKeywords() []LAny {
+func getKeywords() []*LAny {
 	//keywords reserved for the base language that Ell compiles
-	keywords := []LAny{
+	keywords := []*LAny{
 		intern("quote"),
 		intern("def"),
 		intern("defn"),
@@ -86,8 +86,8 @@ func getKeywords() []LAny {
 	return keywords
 }
 
-func getGlobals() []LAny {
-	syms := make([]LAny, 0, symtag)
+func getGlobals() []*LAny {
+	syms := make([]*LAny, 0, symTag)
 	for _, b := range globals {
 		if b != nil {
 			syms = append(syms, b.sym)
@@ -96,7 +96,7 @@ func getGlobals() []LAny {
 	return syms
 }
 
-func globalValue(tag int) LAny {
+func globalValue(tag int) *LAny {
 	if tag < len(globals) {
 		tmp := globals[tag]
 		if tmp != nil {
@@ -109,61 +109,56 @@ func globalValue(tag int) LAny {
 //used to report errors, doesn't need to be fast
 func globalName(tag int) string {
 	for k, v := range symtab {
-		if v.tag == tag {
+		if int(v.ival) == tag {
 			return k
 		}
 	}
 	return "?"
 }
 
-func global(obj LAny) LAny {
-	sym, ok := obj.(*LSymbol)
-	if !ok || sym.tag < 0 || sym.tag >= len(globals) {
+func global(sym *LAny) *LAny {
+	if !isSymbol(sym) || sym.ival < 0 || sym.ival >= len(globals) {
 		return nil
 	}
-	return globalValue(sym.tag)
+	return globalValue(sym.ival)
 }
 
 type binding struct {
-	sym *LSymbol
-	val LAny
+	sym *LAny
+	val *LAny
 }
 
-func defGlobal(sym LAny, val LAny) {
-	s, ok := sym.(*LSymbol)
-	if !ok {
+func defGlobal(sym *LAny, val *LAny) {
+	if !isSymbol(sym) {
 		panic("defGlobal with a non-symbol first argument")
 	}
-	if s.tag >= len(globals) {
-		glob := make([]*binding, s.tag+100)
+	if sym.ival >= len(globals) {
+		glob := make([]*binding, sym.ival+100)
 		copy(glob, globals)
 		globals = glob
 	}
-	b := binding{s, val}
-	globals[s.tag] = &b
+	b := binding{sym, val}
+	globals[sym.ival] = &b
 	delete(macroMap, sym)
 }
 
-func isDefined(sym LAny) bool {
-	s := sym.(*LSymbol)
-	if s.tag < len(globals) {
-		return globals[s.tag] != nil
+func isDefined(sym *LAny) bool {
+	if sym.ival < len(globals) {
+		return globals[sym.ival] != nil
 	}
 	return false
 }
 
-func undefGlobal(sym LAny) {
-	s := sym.(*LSymbol)
-	if s.tag < len(globals) {
-		globals[s.tag] = nil
+func undefGlobal(sym *LAny) {
+	if sym.ival < len(globals) {
+		globals[sym.ival] = nil
 	}
 }
 
-func setGlobal(sym LAny, val LAny) error {
-	s := sym.(*LSymbol)
-	if s.tag < len(globals) {
-		if globals[s.tag] != nil {
-			globals[s.tag].val = val
+func setGlobal(sym *LAny, val *LAny) error {
+	if sym.ival < len(globals) {
+		if globals[sym.ival] != nil {
+			globals[sym.ival].val = val
 			delete(macroMap, sym)
 			return nil
 		}
@@ -172,15 +167,15 @@ func setGlobal(sym LAny, val LAny) error {
 	return Error("*** Warning: set on undefined global ", sym)
 }
 
-func macros() []LAny {
-	keys := make([]LAny, 0, len(macroMap))
+func macros() []*LAny {
+	keys := make([]*LAny, 0, len(macroMap))
 	for k := range macroMap {
 		keys = append(keys, k)
 	}
 	return keys
 }
 
-func getMacro(sym LAny) *macro {
+func getMacro(sym *LAny) *macro {
 	mac, ok := macroMap[sym]
 	if !ok {
 		return nil
@@ -188,13 +183,13 @@ func getMacro(sym LAny) *macro {
 	return mac
 }
 
-func defMacro(sym LAny, val LAny) {
+func defMacro(sym *LAny, val *LAny) {
 	macroMap[sym] = newMacro(sym, val)
 }
 
 //note: unlike java, we cannot use maps or arrays as keys (they are not comparable).
 //so, we will end up with duplicates, unless we do some deep compare, when putting map or array constants
-func putConstant(val LAny) int {
+func putConstant(val *LAny) int {
 	idx, present := constantsMap[val]
 	if !present {
 		idx = len(constants)
@@ -204,13 +199,12 @@ func putConstant(val LAny) int {
 	return idx
 }
 
-func use(sym LAny) error {
-	name := sym.String()
-	return loadModule(name)
+func use(sym *LAny) error {
+	return loadModule(sym.text)
 }
 
-func importCode(thunk *Code) (LAny, error) {
-	result, err := exec(thunk)
+func importCode(thunk *LAny) (*LAny, error) {
+	result, err := exec(thunk.code)
 	if err != nil {
 		return nil, err
 	}
@@ -261,8 +255,8 @@ func loadFile(file string) error {
 		return err
 	}
 
-	expr, err := port.read()
-	defer port.close()
+	expr, err := readInputPort(port)
+	defer closeInputPort(port)
 
 	for {
 		if err != nil {
@@ -275,11 +269,11 @@ func loadFile(file string) error {
 		if err != nil {
 			return err
 		}
-		expr, err = port.read()
+		expr, err = readInputPort(port)
 	}
 }
 
-func eval(expr LAny) (LAny, error) {
+func eval(expr *LAny) (*LAny, error) {
 	if verbose {
 		println("; eval: ", write(expr))
 	}
@@ -316,7 +310,7 @@ func findModuleFile(name string) (string, error) {
 	return name, nil
 }
 
-func compileObject(expr LAny) (string, error) {
+func compileObject(expr *LAny) (string, error) {
 	if verbose {
 		println("; compile: ", write(expr))
 	}
@@ -327,18 +321,18 @@ func compileObject(expr LAny) (string, error) {
 	if verbose {
 		println("; expanded to: ", write(expanded))
 	}
-	code, err := compile(expanded)
+	thunk, err := compile(expanded)
 	if err != nil {
 		return "", err
 	}
 	if verbose {
-		println("; compiled to: ", write(code))
+		println("; compiled to: ", write(thunk))
 	}
-	return code.decompile(true) + "\n", nil
+	return thunk.code.decompile(true) + "\n", nil
 }
 
 //caveats: when you compile a file, you actually run it. This is so we can handle imports and macros correctly.
-func compileFile(name string) (LAny, error) {
+func compileFile(name string) (*LAny, error) {
 	file, err := findModuleFile(name)
 	if err != nil {
 		return nil, err
@@ -351,20 +345,20 @@ func compileFile(name string) (LAny, error) {
 		return nil, err
 	}
 
-	expr, err := port.read()
-	defer port.close()
+	expr, err := readInputPort(port)
+	defer closeInputPort(port)
 	result := ";\n; code generated from " + file + "\n;\n"
 	var lap string
 	for err == nil {
 		if expr == EOF {
-			return LString(result), nil
+			return newString(result), nil
 		}
 		lap, err = compileObject(expr)
 		if err != nil {
 			return nil, err
 		}
 		result += lap
-		expr, err = port.read()
+		expr, err = readInputPort(port)
 	}
 	return nil, err
 }

--- a/module.go
+++ b/module.go
@@ -26,7 +26,7 @@ var constants = make([]*LAny, 0, 1000)
 var globals = make([]*binding, 0, 1000)
 var globalsMap = make(map[*LAny]int, 0)
 var macroMap = make(map[*LAny]*macro, 0)
-var primitives = make([]*LPrimitive, 0, 1000)
+var primitives = make([]*Primitive, 0, 1000)
 
 func checkInterrupt() bool {
 	if interrupts != nil {
@@ -50,7 +50,7 @@ func define(name string, obj *LAny) {
 
 //Need to pass a "signature" string to document usage
 // "(x y [z])" or "(x {y: default})" or "(x & y)" or whatever
-func defineFunction(name string, fun primitive, signature string) {
+func defineFunction(name string, fun PrimCallable, signature string) {
 	sym := intern(name)
 	if global(sym) != nil {
 		println("*** Warning: redefining ", name, " with a primitive")
@@ -60,7 +60,7 @@ func defineFunction(name string, fun primitive, signature string) {
 	defGlobal(sym, prim)
 }
 
-func defineMacro(name string, fun primitive) {
+func defineMacro(name string, fun PrimCallable) {
 	sym := intern(name)
 	if getMacro(sym) != nil {
 		println("*** Warning: redefining macro ", name, " -> ", getMacro(sym))
@@ -73,11 +73,11 @@ func getKeywords() []*LAny {
 	//keywords reserved for the base language that Ell compiles
 	keywords := []*LAny{
 		intern("quote"),
-		intern("def"),
-		intern("defn"),
 		intern("fn"),
 		intern("if"),
 		intern("do"),
+		intern("def"),
+		intern("defn"),
 		intern("defmacro"),
 		intern("set!"),
 		intern("lap"),

--- a/notation.go
+++ b/notation.go
@@ -36,72 +36,61 @@ func fileReadable(path string) bool {
 	return false
 }
 
-// Input - an object to read from
-type Input struct {
+// LPort - readable and writable I/O ports
+type LPort struct {
+	name   string
 	file   *os.File
 	reader *dataReader
-	name   string
+	writer *dataWriter
 }
 
-var typeInput = intern("<input>")
-var typeOutput = intern("<input>")
-
-func isInput(obj LAny) bool {
-	_, ok := obj.(*Input)
-	return ok
+func isInputPort(obj *LAny) bool {
+	return obj.ltype == typePort && obj.port.reader != nil
 }
 
-// Type returns the type of the object
-func (*Input) Type() LAny {
-	return typeInput
+func isOutputPort(obj *LAny) bool {
+	return obj.ltype == typePort && obj.port.writer != nil
 }
 
-// Value returns the object itself for primitive types
-func (in *Input) Value() LAny {
-	return in
-}
-
-func (in *Input) String() string {
-	if in.reader == nil {
-		return fmt.Sprintf("<input: CLOSED %s>", in.name)
+func (port *LPort) String() string {
+	if port.reader != nil {
+		return fmt.Sprintf("#[input-port: %s]", port.name)
 	}
-	return fmt.Sprintf("<input: %s>", in.name)
+	if port.writer != nil {
+		return fmt.Sprintf("#[output-port: %s]", port.name)
+	}
+	return fmt.Sprintf("#[port: CLOSED %s]", port.name)
 }
 
-func (in *Input) Copy() LAny {
-	//not a copy!
-	return in
+func inputPortTypeError(fun string, argnum int, obj *LAny) error {
+	return Error("argument ", argnum, " to ", fun, " is not an input port: ", obj)
 }
 
-// Equal returns true if the object is equal to the argument
-func (in *Input) Equal(another LAny) bool {
-	if a, ok := another.(*Input); ok {
-		return in == a
-	}
-	return false
+func outputPortTypeError(fun string, argnum int, obj *LAny) error {
+	return Error("argument ", argnum, " to ", fun, " is not an output port: ", obj)
 }
 
-func readInput(input LAny) (LAny, error) {
-	switch in := input.(type) {
-	case *Input:
-		return in.read()
-	default:
-		return nil, TypeError(intern("input"), input)
+// --- reader
+
+func readInputPort(in *LAny) (*LAny, error) {
+	if !isInputPort(in) {
+		return nil, inputPortTypeError("read", 1, in)
 	}
+	return in.port.read()
 }
-func closeInput(input LAny) error {
-	switch in := input.(type) {
-	case *Input:
-		return in.close()
-	default:
-		return TypeError(intern("input"), input)
+
+func closeInputPort(in *LAny) error {
+	if !isInputPort(in) {
+		return inputPortTypeError("close-input-port", 1, in)
 	}
+	return in.port.close()
 }
-func (in *Input) read() (LAny, error) {
-	if in.reader == nil {
-		return nil, Error("Input is closed: ", in)
+
+func (port *LPort) read() (*LAny, error) {
+	if port.reader == nil {
+		return nil, Error("Input port is closed: ", port)
 	}
-	obj, err := in.reader.readData()
+	obj, err := port.reader.readData()
 	if err != nil {
 		if err == io.EOF {
 			return EOF, nil
@@ -110,13 +99,15 @@ func (in *Input) read() (LAny, error) {
 	}
 	return obj, nil
 }
-func (in *Input) close() error {
+
+func (port *LPort) close() error {
 	var err error
-	if in.file != nil {
-		err = in.file.Close()
-		in.file = nil
+	if port.file != nil {
+		err = port.file.Close()
+		port.file = nil
 	}
-	in.reader = nil
+	port.reader = nil
+	port.writer = nil
 	return err
 }
 
@@ -130,23 +121,31 @@ func fileContents(path string) (string, error) {
 
 //todo: implement Output
 
-func openInputFile(path string) (*Input, error) {
-	fi, err := os.Open(path)
+func newInputPort(name string, reader *dataReader, fd *os.File) *LAny {
+	return &LAny{ltype: typePort, port: &LPort{file: fd, reader: reader, name: name}}
+}
+
+func openInputFile(path string) (*LAny, error) {
+	fd, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	r := bufio.NewReader(fi)
-	dr := newDataReader(r)
-	return &Input{fi, dr, path}, nil
+	r := bufio.NewReader(fd)
+	reader := newDataReader(r)
+	return newInputPort(path, reader, fd), nil
 }
 
-func openInputString(input string) *Input {
+func openInputString(input string) *LAny {
 	r := strings.NewReader(input)
-	dr := newDataReader(r)
-	return &Input{nil, dr, input}
+	reader := newDataReader(r)
+	return newInputPort(input, reader, nil)
 }
 
-func decode(in io.Reader) (LAny, error) {
+func readInputString(input string) (*LAny, error) {
+	return readInputPort(openInputString(input))
+}
+
+func decode(in io.Reader) (*LAny, error) {
 	br := bufio.NewReader(in)
 	dr := dataReader{br}
 	return dr.readData()
@@ -169,7 +168,7 @@ func (dr *dataReader) ungetChar() error {
 	return dr.in.UnreadByte()
 }
 
-func (dr *dataReader) readData() (LAny, error) {
+func (dr *dataReader) readData() (*LAny, error) {
 	//c, n, e := dr.in.ReadRune()
 	c, e := dr.getChar()
 	for e == nil {
@@ -247,7 +246,7 @@ func (dr *dataReader) decodeComment() error {
 	return e
 }
 
-func (dr *dataReader) decodeString() (LAny, error) {
+func (dr *dataReader) decodeString() (*LAny, error) {
 	buf := []byte{}
 	c, e := dr.getChar()
 	escape := false
@@ -297,11 +296,11 @@ func (dr *dataReader) decodeString() (LAny, error) {
 		}
 		c, e = dr.getChar()
 	}
-	s := LString(string(buf))
+	s := newString(string(buf))
 	return s, e
 }
 
-func (dr *dataReader) decodeList() (LAny, error) {
+func (dr *dataReader) decodeList() (*LAny, error) {
 	items, err := dr.decodeSequence(')')
 	if err != nil {
 		return nil, err
@@ -309,7 +308,7 @@ func (dr *dataReader) decodeList() (LAny, error) {
 	return listFromValues(items), nil
 }
 
-func (dr *dataReader) decodeVector() (LAny, error) {
+func (dr *dataReader) decodeVector() (*LAny, error) {
 	items, err := dr.decodeSequence(']')
 	if err != nil {
 		return nil, err
@@ -336,8 +335,8 @@ func (dr *dataReader) skipToData(skipColon bool) (byte, error) {
 	return 0, err
 }
 
-func (dr *dataReader) decodeStruct() (LAny, error) {
-	items := []LAny{}
+func (dr *dataReader) decodeStruct() (*LAny, error) {
+	items := []*LAny{}
 	var err error
 	var c byte
 	for err == nil {
@@ -374,9 +373,9 @@ func (dr *dataReader) decodeStruct() (LAny, error) {
 	return nil, err
 }
 
-func (dr *dataReader) decodeSequence(endChar byte) ([]LAny, error) {
+func (dr *dataReader) decodeSequence(endChar byte) ([]*LAny, error) {
 	c, err := dr.getChar()
-	items := []LAny{}
+	items := []*LAny{}
 	for err == nil {
 		if isWhitespace(c) {
 			c, err = dr.getChar()
@@ -403,16 +402,12 @@ func (dr *dataReader) decodeSequence(endChar byte) ([]LAny, error) {
 	return nil, err
 }
 
-func (dr *dataReader) decodeAtom(firstChar byte) (LAny, error) {
+func (dr *dataReader) decodeAtom(firstChar byte) (*LAny, error) {
 	s, err := dr.decodeAtomString(firstChar)
 	if err != nil {
 		return nil, err
 	}
 	slen := len(s)
-	if slen == 0 { //?
-		panic("whuh?")
-		return dr.readData()
-	}
 	keyword := false
 	if s[slen-1] == ':' {
 		keyword = true
@@ -433,7 +428,7 @@ func (dr *dataReader) decodeAtom(firstChar byte) (LAny, error) {
 		if keyword {
 			return nil, Error("Keyword cannot have a name that looks like a number: ", s, ":")
 		}
-		return LNumber(f), nil
+		return newFloat64(f), nil
 	}
 	if keyword {
 		s += ":"
@@ -473,6 +468,10 @@ func (dr *dataReader) decodeAtomString(firstChar byte) (string, error) {
 	return s, nil
 }
 
+type dataWriter struct {
+	in *bufio.Writer
+}
+
 func namedChar(name string) (rune, error) {
 	switch name {
 	case "null":
@@ -506,7 +505,7 @@ func namedChar(name string) (rune, error) {
 	}
 }
 
-func (dr *dataReader) decodeReaderMacro() (LAny, error) {
+func (dr *dataReader) decodeReaderMacro() (*LAny, error) {
 	c, e := dr.getChar()
 	if e != nil {
 		return nil, e
@@ -576,7 +575,7 @@ func isDelimiter(b byte) bool {
 	return b == '(' || b == ')' || b == '[' || b == ']' || b == '{' || b == '}' || b == '"' || b == '\'' || b == ';' || b == ':'
 }
 
-func write(obj LAny) string {
+func write(obj *LAny) string {
 	if obj == nil {
 		panic("null pointer")
 	}
@@ -584,32 +583,31 @@ func write(obj LAny) string {
 	return elldn
 }
 
-func writeData(obj LAny, json bool) (string, error) {
+func writeData(obj *LAny, json bool) (string, error) {
 	//an error is never returned for non-json
-	switch o := obj.(type) {
-	case LBoolean, LNull:
-		return o.String(), nil
-	case *LList:
+	switch obj.ltype {
+	case typeBoolean, typeNull, typeNumber:
+		return obj.String(), nil
+	case typeList:
 		if json {
-			return writeVector(listToVector(o), json)
+			return writeVector(listToVector(obj), json)
 		}
-		return writeList(o), nil
-	case *LSymbol:
+		return writeList(obj), nil
+	case typeKeyword:
 		if json {
-			return encodeString(unkeywordedString(o)), nil
+			return encodeString(unkeywordedString(obj)), nil
 		}
-		return o.String(), nil
-	case LString:
-		s := encodeString(string(o))
-		return s, nil
-	case *LVector:
-		return writeVector(o, json)
-	case *LStruct:
-		return writeStruct(o, json)
-	case LNumber:
-		return o.String(), nil
-	case LChar:
-		switch o {
+		return obj.String(), nil
+	case typeSymbol, typeType:
+		return obj.String(), nil
+	case typeString:
+		return encodeString(obj.text), nil
+	case typeVector:
+		return writeVector(obj, json)
+	case typeStruct:
+		return writeStruct(obj, json)
+	case typeCharacter:
+		switch obj.character {
 		case 0:
 			return "#\\null", nil
 		case 7:
@@ -629,23 +627,23 @@ func writeData(obj LAny, json bool) (string, error) {
 		case 127:
 			return "#\\delete", nil
 		default:
-			if o < 127 {
-				return "#\\" + string(rune(o)), nil
+			if obj.character < 127 {
+				return "#\\" + string(obj.character), nil
 			}
-			return fmt.Sprintf("#\\x%04X", int(o)), nil
+			return fmt.Sprintf("#\\x%04X", int(obj.character)), nil
 		}
 	default:
 		if json {
 			return "", Error("data cannot be described in JSON: ", obj)
 		}
-		if o == nil {
+		if obj == nil {
 			panic("whoops: nil not allowed here!")
 		}
-		return o.String(), nil
+		return obj.String(), nil
 	}
 }
 
-func writeList(lst *LList) string {
+func writeList(lst *LAny) string {
 	if lst == EmptyList {
 		return "()"
 	}
@@ -674,12 +672,12 @@ func writeList(lst *LList) string {
 	return buf.String()
 }
 
-func writeVector(ary *LVector, json bool) (string, error) {
+func writeVector(vec *LAny, json bool) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	vlen := len(ary.elements)
+	vlen := len(vec.elements)
 	if vlen > 0 {
-		s, err := writeData(ary.elements[0], json)
+		s, err := writeData(vec.elements[0], json)
 		if err != nil {
 			return "", err
 		}
@@ -689,7 +687,7 @@ func writeVector(ary *LVector, json bool) (string, error) {
 			delim = ", "
 		}
 		for i := 1; i < vlen; i++ {
-			s, err := writeData(ary.elements[i], json)
+			s, err := writeData(vec.elements[i], json)
 			if err != nil {
 				return "", err
 			}
@@ -701,20 +699,20 @@ func writeVector(ary *LVector, json bool) (string, error) {
 	return buf.String(), nil
 }
 
-func writeStruct(m *LStruct, json bool) (string, error) {
+func writeStruct(strct *LAny, json bool) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("{")
-	first := true
 	delim := ", "
 	sep := " "
 	if json {
 		delim = ", "
 		sep = ": "
 	}
-	for k, v := range m.bindings {
-		if first {
-			first = false
-		} else {
+	size := len(strct.elements)
+	for i := 0; i < size; i += 2 {
+		k := strct.elements[i]
+		v := strct.elements[i+1]
+		if i != 0 {
 			buf.WriteString(delim)
 		}
 		s, err := writeData(k, json)
@@ -731,12 +729,11 @@ func writeStruct(m *LStruct, json bool) (string, error) {
 	}
 	buf.WriteString("}")
 	return buf.String(), nil
-
 }
 
 //return a JSON string of the object, or an error if it cannot be expressed in JSON
 //this is very close to EllDn, the standard output format. Exceptions:
 //  1. the only symbols allowed are true, false, null
-func toJSON(obj LAny) (string, error) {
+func toJSON(obj *LAny) (string, error) {
 	return writeData(obj, true)
 }

--- a/number.go
+++ b/number.go
@@ -21,15 +21,24 @@ import (
 )
 
 func newFloat64(f float64) *LAny {
-	return &LAny{ltype: typeNumber, fval: f}
+	num := new(LAny)
+	num.ltype = typeNumber
+	num.fval = f
+	return num
 }
 
 func newInt64(i int64) *LAny {
-	return &LAny{ltype: typeNumber, fval: float64(i)}
+	num := new(LAny)
+	num.ltype = typeNumber
+	num.fval = float64(i)
+	return num
 }
 
 func newInt(i int) *LAny {
-	return &LAny{ltype: typeNumber, fval: float64(i)}
+	num := new(LAny)
+	num.ltype = typeNumber
+	num.fval = float64(i)
+	return num
 }
 
 func isInt(obj *LAny) bool {

--- a/number.go
+++ b/number.go
@@ -18,41 +18,23 @@ package main
 
 import (
 	"math"
-	"strconv"
 )
 
-type LNumber float64 // <number>
-
-var typeNumber = intern("<number>")
-
-// Type returns the type of the object
-func (LNumber) Type() LAny {
-	return typeNumber
+func newFloat64(f float64) *LAny {
+	return &LAny{ltype: typeNumber, fval: f}
 }
 
-// Value returns the object itself for primitive types
-func (f LNumber) Value() LAny {
-	return f
+func newInt64(i int64) *LAny {
+	return &LAny{ltype: typeNumber, fval: float64(i)}
 }
 
-func (f LNumber) String() string {
-	return strconv.FormatFloat(float64(f), 'f', -1, 64)
+func newInt(i int) *LAny {
+	return &LAny{ltype: typeNumber, fval: float64(i)}
 }
 
-func (f LNumber) Copy() LAny {
-	return f
-}
-
-func theNumber(obj LAny) (LNumber, error) {
-	if n, ok := obj.(LNumber); ok {
-		return n, nil
-	}
-	return 0, TypeError(typeNumber, obj)
-}
-
-func isInt(obj LAny) bool {
-	if n, ok := obj.(LNumber); ok {
-		f := float64(n)
+func isInt(obj *LAny) bool {
+	if obj.ltype == typeNumber {
+		f := obj.fval
 		if math.Trunc(f) == f {
 			return true
 		}
@@ -60,133 +42,124 @@ func isInt(obj LAny) bool {
 	return false
 }
 
-func isFloat(obj LAny) bool {
-	return !isInt(obj)
-}
-
-func isNumber(obj LAny) bool {
-	_, ok := obj.(LNumber)
-	return ok
-}
-
-func floatValue(obj LAny) (float64, error) {
-	switch n := obj.(type) {
-	case LNumber:
-		return float64(n), nil
-	}
-	return 0, TypeError(typeNumber, obj)
-}
-
-func int64Value(obj LAny) (int64, error) {
-	switch n := obj.(type) {
-	case LNumber:
-		return int64(n), nil
-	case LChar:
-		return int64(n), nil
-	default:
-		return 0, TypeError(typeNumber, obj)
-	}
-}
-
-func intValue(obj LAny) (int, error) {
-	switch n := obj.(type) {
-	case LNumber:
-		return int(n), nil
-	case LChar:
-		return int(n), nil
-	default:
-		return 0, TypeError(typeNumber, obj)
-	}
-}
-
-// Equal returns true if the object is equal to the argument
-func greaterOrEqual(n1 LAny, n2 LAny) (LAny, error) {
-	f1, err := floatValue(n1)
-	if err == nil {
-		f2, err := floatValue(n2)
-		if err == nil {
-			if f1 >= f2 {
-				return True, nil
-			}
-			return False, nil
-		}
-		return nil, err
-	}
-	return nil, err
-}
-
-func lessOrEqual(n1 LAny, n2 LAny) (LAny, error) {
-	f1, err := floatValue(n1)
-	if err == nil {
-		f2, err := floatValue(n2)
-		if err == nil {
-			if f1 <= f2 {
-				return True, nil
-			}
-			return False, nil
-		}
-		return nil, err
-	}
-	return nil, err
-}
-
-func greater(n1 LAny, n2 LAny) (LAny, error) {
-	f1, err := floatValue(n1)
-	if err == nil {
-		f2, err := floatValue(n2)
-		if err == nil {
-			if f1 > f2 {
-				return True, nil
-			}
-			return False, nil
-		}
-		return nil, err
-	}
-	return nil, err
-}
-
-func less(n1 LAny, n2 LAny) (LAny, error) {
-	f1, err := floatValue(n1)
-	if err == nil {
-		f2, err := floatValue(n2)
-		if err == nil {
-			if f1 < f2 {
-				return True, nil
-			}
-			return False, nil
-		}
-		return nil, err
-	}
-	return nil, err
-}
-
-func numericallyEqual(o1 LAny, o2 LAny) (bool, error) {
-	switch n1 := o1.(type) {
-	case LNumber:
-		switch n2 := o2.(type) {
-		case LNumber:
-			return n1 == n2, nil
-		default:
-			return false, TypeError(typeNumber, o2)
-		}
-	default:
-		return false, TypeError(typeNumber, o1)
-	}
-}
-
-func identical(n1 LAny, n2 LAny) bool {
-	return n1 == n2
-}
-
-// Equal returns true if the object is equal to the argument
-func (f LNumber) Equal(another LAny) bool {
-	if a, err := floatValue(another); err == nil {
-		return float64(f) == a
+func isFloat(obj *LAny) bool {
+	if obj.ltype == typeNumber {
+		return !isInt(obj)
 	}
 	return false
 }
 
-func add(num1 LAny, num2 LAny) (LAny, error) {
+func floatValue(obj *LAny) (float64, error) {
+	if obj.ltype == typeNumber {
+		return obj.fval, nil
+	}
+	return 0, TypeError(typeNumber, obj)
+}
+
+func int64Value(obj *LAny) (int64, error) {
+	if obj.ltype == typeNumber {
+		return int64(obj.fval), nil
+	}
+	return 0, TypeError(typeNumber, obj)
+}
+
+func intValue(obj *LAny) (int, error) {
+	if obj.ltype == typeNumber {
+		return int(obj.fval), nil
+	}
+	return 0, TypeError(typeNumber, obj)
+}
+
+// Equal returns true if the object is equal to the argument
+func greaterOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+	f1, err := floatValue(n1)
+	if err != nil {
+		return nil, err
+	}
+	f2, err := floatValue(n2)
+	if err != nil {
+		return nil, err
+	}
+	if f1 >= f2 {
+		return True, nil
+	}
+	return False, nil
+}
+
+func lessOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+	f1, err := floatValue(n1)
+	if err != nil {
+		return nil, err
+	}
+	f2, err := floatValue(n2)
+	if err != nil {
+		return nil, err
+	}
+	if f1 <= f2 {
+		return True, nil
+	}
+	return False, nil
+}
+
+func greater(n1 *LAny, n2 *LAny) (*LAny, error) {
+	f1, err := floatValue(n1)
+	if err != nil {
+		return nil, err
+	}
+	f2, err := floatValue(n2)
+	if err != nil {
+		return nil, err
+	}
+	if f1 > f2 {
+		return True, nil
+	}
+	return False, nil
+}
+
+func less(n1 *LAny, n2 *LAny) (*LAny, error) {
+	f1, err := floatValue(n1)
+	if err != nil {
+		return nil, err
+	}
+	f2, err := floatValue(n2)
+	if err != nil {
+		return nil, err
+	}
+	if f1 < f2 {
+		return True, nil
+	}
+	return False, nil
+}
+
+const epsilon = 0.000000001
+
+// Equal returns true if the object is equal to the argument, within epsilon
+func numberEqual(f1 float64, f2 float64) bool {
+	if f1 == f2 {
+		return true
+	}
+	if math.Abs(f1-f2) < epsilon {
+		return true
+	}
+	return false
+}
+
+func numericallyEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+	f1, err := floatValue(n1)
+	if err != nil {
+		return nil, err
+	}
+	f2, err := floatValue(n2)
+	if err != nil {
+		return nil, err
+	}
+	if numberEqual(f1, f2) {
+		return True, nil
+	}
+	return False, nil
+}
+
+func add(num1 *LAny, num2 *LAny) (*LAny, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -195,23 +168,21 @@ func add(num1 LAny, num2 LAny) (LAny, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LNumber(n1 + n2), nil
+	return newFloat64(n1 + n2), nil
 }
 
-func sum(nums []LAny, argc int) (LAny, error) {
+func sum(nums []*LAny, argc int) (*LAny, error) {
 	var sum float64
 	for _, num := range nums {
-		switch n := num.(type) {
-		case LNumber:
-			sum += float64(n)
-		default:
+		if !isNumber(num) {
 			return nil, TypeError(typeNumber, num)
 		}
+		sum += float64(num.fval)
 	}
-	return LNumber(sum), nil
+	return newFloat64(sum), nil
 }
 
-func sub(num1 LAny, num2 LAny) (LAny, error) {
+func sub(num1 *LAny, num2 *LAny) (*LAny, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -220,37 +191,32 @@ func sub(num1 LAny, num2 LAny) (LAny, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LNumber(n1 - n2), nil
+	return newFloat64(n1 - n2), nil
 }
 
-func minus(nums []LAny, argc int) (LAny, error) {
+func minus(nums []*LAny, argc int) (*LAny, error) {
 	if argc < 1 {
 		return nil, ArgcError("-", "1+", argc)
 	}
-	var fsum float64
-	num := nums[0]
-	switch n := num.(type) {
-	case LNumber:
-		fsum = float64(n)
-	default:
-		return nil, TypeError(typeNumber, num)
+	fsum, err := floatValue(nums[0])
+	if err != nil {
+		return nil, err
 	}
 	if argc == 1 {
 		fsum = -fsum
 	} else {
 		for _, num := range nums[1:] {
-			switch n := num.(type) {
-			case LNumber:
-				fsum -= float64(n)
-			default:
-				return nil, TypeError(typeNumber, num)
+			f, err := floatValue(num)
+			if err != nil {
+				return nil, err
 			}
+			fsum -= f
 		}
 	}
-	return LNumber(fsum), nil
+	return newFloat64(fsum), nil
 }
 
-func mul(num1 LAny, num2 LAny) (LAny, error) {
+func mul(num1 *LAny, num2 *LAny) (*LAny, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -259,23 +225,22 @@ func mul(num1 LAny, num2 LAny) (LAny, error) {
 	if err != nil {
 		return nil, err
 	}
-	return LNumber(n1 * n2), nil
+	return newFloat64(n1 * n2), nil
 }
 
-func product(argv []LAny, argc int) (LAny, error) {
+func product(argv []*LAny, argc int) (*LAny, error) {
 	prod := 1.0
 	for _, num := range argv {
-		switch n := num.(type) {
-		case LNumber:
-			prod *= float64(n)
-		default:
-			return nil, TypeError(typeNumber, num)
+		f, err := floatValue(num)
+		if err != nil {
+			return nil, err
 		}
+		prod *= f
 	}
-	return LNumber(prod), nil
+	return newFloat64(prod), nil
 }
 
-func div(argv []LAny, argc int) (LAny, error) {
+func div(argv []*LAny, argc int) (*LAny, error) {
 	if argc < 1 {
 		return nil, ArgcError("/", "1+", argc)
 	} else if argc == 1 {
@@ -283,7 +248,7 @@ func div(argv []LAny, argc int) (LAny, error) {
 		if err != nil {
 			return nil, err
 		}
-		return LNumber(1.0 / n1), nil
+		return newFloat64(1.0 / n1), nil
 	} else {
 		quo, err := floatValue(argv[0])
 		if err != nil {
@@ -296,6 +261,6 @@ func div(argv []LAny, argc int) (LAny, error) {
 			}
 			quo /= n
 		}
-		return LNumber(quo), nil
+		return newFloat64(quo), nil
 	}
 }

--- a/number.go
+++ b/number.go
@@ -20,29 +20,26 @@ import (
 	"math"
 )
 
-func newFloat64(f float64) *LAny {
-	num := new(LAny)
-	num.ltype = typeNumber
+func newFloat64(f float64) *LOB {
+	num := newLOB(typeNumber)
 	num.fval = f
 	return num
 }
 
-func newInt64(i int64) *LAny {
-	num := new(LAny)
-	num.ltype = typeNumber
+func newInt64(i int64) *LOB {
+	num := newLOB(typeNumber)
 	num.fval = float64(i)
 	return num
 }
 
-func newInt(i int) *LAny {
-	num := new(LAny)
-	num.ltype = typeNumber
+func newInt(i int) *LOB {
+	num := newLOB(typeNumber)
 	num.fval = float64(i)
 	return num
 }
 
-func isInt(obj *LAny) bool {
-	if obj.ltype == typeNumber {
+func isInt(obj *LOB) bool {
+	if obj.variant == typeNumber {
 		f := obj.fval
 		if math.Trunc(f) == f {
 			return true
@@ -51,36 +48,36 @@ func isInt(obj *LAny) bool {
 	return false
 }
 
-func isFloat(obj *LAny) bool {
-	if obj.ltype == typeNumber {
+func isFloat(obj *LOB) bool {
+	if obj.variant == typeNumber {
 		return !isInt(obj)
 	}
 	return false
 }
 
-func floatValue(obj *LAny) (float64, error) {
-	if obj.ltype == typeNumber {
+func floatValue(obj *LOB) (float64, error) {
+	if obj.variant == typeNumber {
 		return obj.fval, nil
 	}
 	return 0, TypeError(typeNumber, obj)
 }
 
-func int64Value(obj *LAny) (int64, error) {
-	if obj.ltype == typeNumber {
+func int64Value(obj *LOB) (int64, error) {
+	if obj.variant == typeNumber {
 		return int64(obj.fval), nil
 	}
 	return 0, TypeError(typeNumber, obj)
 }
 
-func intValue(obj *LAny) (int, error) {
-	if obj.ltype == typeNumber {
+func intValue(obj *LOB) (int, error) {
+	if obj.variant == typeNumber {
 		return int(obj.fval), nil
 	}
 	return 0, TypeError(typeNumber, obj)
 }
 
 // Equal returns true if the object is equal to the argument
-func greaterOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+func greaterOrEqual(n1 *LOB, n2 *LOB) (*LOB, error) {
 	f1, err := floatValue(n1)
 	if err != nil {
 		return nil, err
@@ -95,7 +92,7 @@ func greaterOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
 	return False, nil
 }
 
-func lessOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+func lessOrEqual(n1 *LOB, n2 *LOB) (*LOB, error) {
 	f1, err := floatValue(n1)
 	if err != nil {
 		return nil, err
@@ -110,7 +107,7 @@ func lessOrEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
 	return False, nil
 }
 
-func greater(n1 *LAny, n2 *LAny) (*LAny, error) {
+func greater(n1 *LOB, n2 *LOB) (*LOB, error) {
 	f1, err := floatValue(n1)
 	if err != nil {
 		return nil, err
@@ -125,7 +122,7 @@ func greater(n1 *LAny, n2 *LAny) (*LAny, error) {
 	return False, nil
 }
 
-func less(n1 *LAny, n2 *LAny) (*LAny, error) {
+func less(n1 *LOB, n2 *LOB) (*LOB, error) {
 	f1, err := floatValue(n1)
 	if err != nil {
 		return nil, err
@@ -153,7 +150,7 @@ func numberEqual(f1 float64, f2 float64) bool {
 	return false
 }
 
-func numericallyEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
+func numericallyEqual(n1 *LOB, n2 *LOB) (*LOB, error) {
 	f1, err := floatValue(n1)
 	if err != nil {
 		return nil, err
@@ -168,7 +165,7 @@ func numericallyEqual(n1 *LAny, n2 *LAny) (*LAny, error) {
 	return False, nil
 }
 
-func add(num1 *LAny, num2 *LAny) (*LAny, error) {
+func add(num1 *LOB, num2 *LOB) (*LOB, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -180,7 +177,7 @@ func add(num1 *LAny, num2 *LAny) (*LAny, error) {
 	return newFloat64(n1 + n2), nil
 }
 
-func sum(nums []*LAny, argc int) (*LAny, error) {
+func sum(nums []*LOB, argc int) (*LOB, error) {
 	var sum float64
 	for _, num := range nums {
 		if !isNumber(num) {
@@ -191,7 +188,7 @@ func sum(nums []*LAny, argc int) (*LAny, error) {
 	return newFloat64(sum), nil
 }
 
-func sub(num1 *LAny, num2 *LAny) (*LAny, error) {
+func sub(num1 *LOB, num2 *LOB) (*LOB, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -203,7 +200,7 @@ func sub(num1 *LAny, num2 *LAny) (*LAny, error) {
 	return newFloat64(n1 - n2), nil
 }
 
-func minus(nums []*LAny, argc int) (*LAny, error) {
+func minus(nums []*LOB, argc int) (*LOB, error) {
 	if argc < 1 {
 		return nil, ArgcError("-", "1+", argc)
 	}
@@ -225,7 +222,7 @@ func minus(nums []*LAny, argc int) (*LAny, error) {
 	return newFloat64(fsum), nil
 }
 
-func mul(num1 *LAny, num2 *LAny) (*LAny, error) {
+func mul(num1 *LOB, num2 *LOB) (*LOB, error) {
 	n1, err := floatValue(num1)
 	if err != nil {
 		return nil, err
@@ -237,7 +234,7 @@ func mul(num1 *LAny, num2 *LAny) (*LAny, error) {
 	return newFloat64(n1 * n2), nil
 }
 
-func product(argv []*LAny, argc int) (*LAny, error) {
+func product(argv []*LOB, argc int) (*LOB, error) {
 	prod := 1.0
 	for _, num := range argv {
 		f, err := floatValue(num)
@@ -249,7 +246,7 @@ func product(argv []*LAny, argc int) (*LAny, error) {
 	return newFloat64(prod), nil
 }
 
-func div(argv []*LAny, argc int) (*LAny, error) {
+func div(argv []*LOB, argc int) (*LOB, error) {
 	if argc < 1 {
 		return nil, ArgcError("/", "1+", argc)
 	} else if argc == 1 {

--- a/repl.go
+++ b/repl.go
@@ -32,7 +32,7 @@ func (ell *ellHandler) Eval(expr string) (string, bool, error) {
 		if whole == "" {
 			return "", false, nil
 		}
-		lexpr, err := openInputString(whole).read()
+		lexpr, err := readInputString(whole)
 		ell.buf = ""
 		if err == nil {
 			val, err := eval(lexpr)
@@ -122,7 +122,7 @@ func (ell *ellHandler) Complete(expr string) (string, []string) {
 	matches := []string{}
 	addendum := ""
 	prefix, funPosition := ell.completePrefix(expr)
-	candidates := map[LAny]bool{}
+	candidates := map[*LAny]bool{}
 	if funPosition {
 		for _, sym := range getKeywords() {
 			str := sym.String()

--- a/repl.go
+++ b/repl.go
@@ -122,7 +122,7 @@ func (ell *ellHandler) Complete(expr string) (string, []string) {
 	matches := []string{}
 	addendum := ""
 	prefix, funPosition := ell.completePrefix(expr)
-	candidates := map[*LAny]bool{}
+	candidates := map[*LOB]bool{}
 	if funPosition {
 		for _, sym := range getKeywords() {
 			str := sym.String()

--- a/string.go
+++ b/string.go
@@ -16,7 +16,10 @@ limitations under the License.
 package main
 
 func newString(s string) *LAny {
-	return &LAny{ltype: typeString, text: s}
+	str := new(LAny)
+	str.ltype = typeString
+	str.text = s
+	return str
 }
 
 func asString(obj *LAny) (string, error) {
@@ -66,7 +69,10 @@ func encodeString(s string) string {
 }
 
 func newCharacter(c rune) *LAny {
-	return &LAny{ltype: typeCharacter, character: c}
+	char := new(LAny)
+	char.ltype = typeCharacter
+	char.character = c
+	return char
 }
 
 func asCharacter(c *LAny) (rune, error) {

--- a/string.go
+++ b/string.go
@@ -15,21 +15,20 @@ limitations under the License.
 */
 package main
 
-func newString(s string) *LAny {
-	str := new(LAny)
-	str.ltype = typeString
+func newString(s string) *LOB {
+	str := newLOB(typeString)
 	str.text = s
 	return str
 }
 
-func asString(obj *LAny) (string, error) {
+func asString(obj *LOB) (string, error) {
 	if !isString(obj) {
 		return "", TypeError(typeString, obj)
 	}
 	return obj.text, nil
 }
 
-func toString(a *LAny) *LAny {
+func toString(a *LOB) *LOB {
 	return newString(a.String())
 }
 
@@ -68,32 +67,31 @@ func encodeString(s string) string {
 	return string(buf)
 }
 
-func newCharacter(c rune) *LAny {
-	char := new(LAny)
-	char.ltype = typeCharacter
+func newCharacter(c rune) *LOB {
+	char := newLOB(typeCharacter)
 	char.character = c
 	return char
 }
 
-func asCharacter(c *LAny) (rune, error) {
+func asCharacter(c *LOB) (rune, error) {
 	if !isCharacter(c) {
 		return 0, TypeError(typeCharacter, c)
 	}
 	return c.character, nil
 }
 
-func stringCharacters(s *LAny) []*LAny {
-	chars := make([]*LAny, len(s.text))
+func stringCharacters(s *LOB) []*LOB {
+	chars := make([]*LOB, len(s.text))
 	for i, c := range s.text {
 		chars[i] = newCharacter(c)
 	}
 	return chars
 }
 
-func stringToVector(s *LAny) *LAny {
+func stringToVector(s *LOB) *LOB {
 	return vector(stringCharacters(s)...)
 }
 
-func stringToList(s *LAny) *LAny {
+func stringToList(s *LOB) *LOB {
 	return list(stringCharacters(s)...)
 }

--- a/string.go
+++ b/string.go
@@ -15,44 +15,19 @@ limitations under the License.
 */
 package main
 
-type LString string // <string>
-
-var typeString = intern("<string>")
-
-func isString(obj LAny) bool {
-	_, ok := obj.(LString)
-	return ok
+func newString(s string) *LAny {
+	return &LAny{ltype: typeString, text: s}
 }
 
-func stringValue(obj LAny) (string, error) {
-	switch s := obj.(type) {
-	case LString:
-		return string(s), nil
-	default:
+func asString(obj *LAny) (string, error) {
+	if !isString(obj) {
 		return "", TypeError(typeString, obj)
 	}
+	return obj.text, nil
 }
 
-// Type returns the type of the object
-func (LString) Type() LAny {
-	return typeString
-}
-
-// Value returns the object itself for primitive types
-func (s LString) Value() LAny {
-	return s
-}
-
-// Equal returns true if the object is equal to the argument
-func (s LString) Equal(another LAny) bool {
-	if a, ok := another.(LString); ok {
-		return s == a
-	}
-	return false
-}
-
-func (s LString) Copy() LAny {
-	return s
+func toString(a *LAny) *LAny {
+	return newString(a.String())
 }
 
 func encodeString(s string) string {
@@ -90,69 +65,29 @@ func encodeString(s string) string {
 	return string(buf)
 }
 
-func (s LString) String() string {
-	return string(s)
+func newCharacter(c rune) *LAny {
+	return &LAny{ltype: typeCharacter, character: c}
 }
 
-//
-// LChar - Ell characters
-//
-type LChar rune // <char>
-
-var typeChar = intern("<char>")
-
-func isChar(obj LAny) bool {
-	_, ok := obj.(LChar)
-	if ok {
-		return true
+func asCharacter(c *LAny) (rune, error) {
+	if !isCharacter(c) {
+		return 0, TypeError(typeCharacter, c)
 	}
-	return ok
+	return c.character, nil
 }
 
-func newCharacter(c rune) LChar {
-	v := LChar(c)
-	return v
-}
-
-// Type returns the type of the object
-func (LChar) Type() LAny {
-	return typeChar
-}
-
-// Value returns the object itself for primitive types
-func (i LChar) Value() LAny {
-	return i
-}
-
-// Equal returns true if the object is equal to the argument
-func (i LChar) Equal(another LAny) bool {
-	if a, err := intValue(another); err == nil {
-		return int(i) == a
-	}
-	return false
-}
-
-func (i LChar) String() string {
-	buf := []rune{rune(i)}
-	return string(buf)
-}
-
-func (i LChar) Copy() LAny {
-	return i
-}
-
-func stringChars(s LString) []LAny {
-	chars := make([]LAny, len(s))
-	for i, c := range s {
-		chars[i] = LChar(c)
+func stringCharacters(s *LAny) []*LAny {
+	chars := make([]*LAny, len(s.text))
+	for i, c := range s.text {
+		chars[i] = newCharacter(c)
 	}
 	return chars
 }
 
-func stringToVector(s LString) LAny {
-	return vector(stringChars(s)...)
+func stringToVector(s *LAny) *LAny {
+	return vector(stringCharacters(s)...)
 }
 
-func stringToList(s LString) LAny {
-	return list(stringChars(s)...)
+func stringToList(s *LAny) *LAny {
+	return list(stringCharacters(s)...)
 }

--- a/struct.go
+++ b/struct.go
@@ -22,7 +22,9 @@ import (
 
 func newStruct(fieldvals []*LAny) (*LAny, error) {
 	count := len(fieldvals)
-	strct := &LAny{ltype: typeStruct, elements: make([]*LAny, 0, count)}
+	strct := new(LAny)
+	strct.ltype = typeStruct
+	strct.elements = make([]*LAny, 0, count)
 	i := 0
 	for i < count {
 		o := fieldvals[i]
@@ -265,15 +267,3 @@ func structToVector(s *LAny) *LAny {
 	}
 	return vectorFromElements(el, size)
 }
-
-/*
-func copyStruct(s *LAny) *LAny {
-	size := len(s.elements)
-	elements := make([]*LAny, size)
-	for i := 0; i < size; i += 2 {
-		elements[i] = s.elements[i]
-		elements[i+1] = elements[i].copy()
-   }
-   return &LAny{ltype: typeStruct, elements: elements}
-}
-*/

--- a/symbol.go
+++ b/symbol.go
@@ -17,17 +17,17 @@ package main
 
 var symTag int
 
-func intern(name string) *LAny {
+func intern(name string) *LOB {
 	sym, ok := symtab[name]
 	if !ok {
-		sym = new(LAny)
+		sym = new(LOB)
 		sym.text = name
 		if isValidKeywordName(name) {
-			sym.ltype = typeKeyword
+			sym.variant = typeKeyword
 		} else if isValidTypeName(name) {
-			sym.ltype = typeType
+			sym.variant = typeType
 		} else if isValidSymbolName(name) {
-			sym.ltype = typeSymbol
+			sym.variant = typeSymbol
 			sym.ival = symTag
 			symTag++
 		} else {
@@ -38,7 +38,7 @@ func intern(name string) *LAny {
 	return sym
 }
 
-func symbolTag(sym *LAny) int {
+func symbolTag(sym *LOB) int {
 	return sym.ival
 }
 
@@ -63,21 +63,21 @@ func isValidKeywordName(s string) bool {
 }
 
 // <type> -> <symbol>
-func typeName(t *LAny) (*LAny, error) {
+func typeName(t *LOB) (*LOB, error) {
 	if !isType(t) {
 		return nil, Error("Type error: expected <type>, got ", t)
 	}
 	return intern(t.text[1 : len(t.text)-1]), nil
 }
 
-func unkeywordedString(k *LAny) string {
+func unkeywordedString(k *LOB) string {
 	if isKeyword(k) {
 		return k.text[:len(k.text)-1]
 	}
 	return k.text
 }
 
-func unkeyworded(obj *LAny) (*LAny, error) {
+func unkeyworded(obj *LOB) (*LOB, error) {
 	if isSymbol(obj) {
 		return obj, nil
 	}
@@ -87,7 +87,7 @@ func unkeyworded(obj *LAny) (*LAny, error) {
 	return nil, Error("Type error: expected <keyword> or <symbol>, got ", obj)
 }
 
-func keywordToSymbol(obj *LAny) (*LAny, error) {
+func keywordToSymbol(obj *LOB) (*LOB, error) {
 	if isKeyword(obj) {
 		return intern(obj.text[:len(obj.text)-1]), nil
 	}
@@ -97,30 +97,30 @@ func keywordToSymbol(obj *LAny) (*LAny, error) {
 //the global symbol table. symbols for the basic types defined in this file are precached
 var symtab = initSymbolTable()
 
-func initSymbolTable() map[string]*LAny {
-	syms := make(map[string]*LAny, 0)
-	typeType = &LAny{text: "<type>"}
-	typeType.ltype = typeType //mutate to bootstrap type type
+func initSymbolTable() map[string]*LOB {
+	syms := make(map[string]*LOB, 0)
+	typeType = &LOB{text: "<type>"}
+	typeType.variant = typeType //mutate to bootstrap type type
 	syms[typeType.text] = typeType
 
-	typeKeyword = &LAny{ltype: typeType, text: "<keyword>"}
+	typeKeyword = &LOB{variant: typeType, text: "<keyword>"}
 	syms[typeKeyword.text] = typeKeyword
 
-	typeSymbol = &LAny{ltype: typeType, text: "<symbol>"}
+	typeSymbol = &LOB{variant: typeType, text: "<symbol>"}
 	syms[typeSymbol.text] = typeSymbol
 
 	return syms
 }
 
-func symbols() []*LAny {
-	syms := make([]*LAny, 0, len(symtab))
+func symbols() []*LOB {
+	syms := make([]*LOB, 0, len(symtab))
 	for _, sym := range symtab {
 		syms = append(syms, sym)
 	}
 	return syms
 }
 
-func symbol(names []*LAny) (*LAny, error) {
+func symbol(names []*LOB) (*LOB, error) {
 	size := len(names)
 	if size < 1 {
 		return nil, ArgcError("symbol", "1+", size)
@@ -129,7 +129,7 @@ func symbol(names []*LAny) (*LAny, error) {
 	for i := 0; i < size; i++ {
 		o := names[i]
 		s := ""
-		switch o.ltype {
+		switch o.variant {
 		case typeString, typeSymbol:
 			s = o.text
 		default:

--- a/symbol.go
+++ b/symbol.go
@@ -20,15 +20,17 @@ var symTag int
 func intern(name string) *LAny {
 	sym, ok := symtab[name]
 	if !ok {
+		sym = new(LAny)
+		sym.text = name
 		if isValidKeywordName(name) {
-			sym = &LAny{ltype: typeKeyword, text: name}
+			sym.ltype = typeKeyword
 		} else if isValidTypeName(name) {
-			sym = &LAny{ltype: typeType, text: name}
+			sym.ltype = typeType
 		} else if isValidSymbolName(name) {
-			sym = &LAny{ltype: typeSymbol, text: name, ival: symTag}
+			sym.ltype = typeSymbol
+			sym.ival = symTag
 			symTag++
-		}
-		if sym == nil {
+		} else {
 			panic("invalid symbol/type/keyword name passed to intern: " + name)
 		}
 		symtab[name] = sym
@@ -97,17 +99,14 @@ var symtab = initSymbolTable()
 
 func initSymbolTable() map[string]*LAny {
 	syms := make(map[string]*LAny, 0)
-	typeType = &LAny{text: "<type>", ival: symTag}
-	symTag++
+	typeType = &LAny{text: "<type>"}
 	typeType.ltype = typeType //mutate to bootstrap type type
 	syms[typeType.text] = typeType
 
-	typeKeyword = &LAny{ltype: typeType, text: "<keyword>", ival: symTag}
-	symTag++
+	typeKeyword = &LAny{ltype: typeType, text: "<keyword>"}
 	syms[typeKeyword.text] = typeKeyword
 
-	typeSymbol = &LAny{ltype: typeType, text: "<symbol>", ival: symTag}
-	symTag++
+	typeSymbol = &LAny{ltype: typeType, text: "<symbol>"}
 	syms[typeSymbol.text] = typeSymbol
 
 	return syms

--- a/tests/argbinding_test.ell
+++ b/tests/argbinding_test.ell
@@ -40,6 +40,7 @@
 (test (fun_opt_default 1 2) '(1 2 57) "(fun_opt_default 1 2)")
 (test (fun_opt_default 1 2 3) '(1 2 3) "(fun_opt_default 1 2 3)")
 
+
 (defn fun_keyargs (x {y: 23, z 57}) (list x y z)) ; note that colons are optional, so are commas
 (test (fun_keyargs 1) '(1 23 57) "(fun_keyargs 1)")
 (test (fun_keyargs 1 y: 2) '(1 2 57) "(fun_keyargs 1 y: 2)")
@@ -51,4 +52,5 @@
 (test (fun_keyonly) '(23) "(fun_keyonly)")
 (test (fun_keyonly y: 100) '(100) "(fun_keyonly y: 100)")
 
+(println "[argbinding_test OK]")
 

--- a/tests/deftype_test.ell
+++ b/tests/deftype_test.ell
@@ -14,4 +14,4 @@
 ; error, as string-length must exactly have a string as an arg
 ;(assert (= (string-length s) (string-length b))) ; b can be treated as string?
 
-
+(println "[deftype_test OK]")

--- a/tests/for_range_test.ell
+++ b/tests/for_range_test.ell
@@ -14,3 +14,4 @@
 (assert-equal '([1] [2] [3]) (for ((x (range 1 4))) [x]))
 (assert-equal '([1 a] [1 b] [1 c] [2 a] [2 b] [2 c] [3 a] [3 b] [3 c]) (for ((x (range 1 4)) (y '(a b c))) [x y]))
 
+(println "[for_range_test OK]")

--- a/tests/json_test.ell
+++ b/tests/json_test.ell
@@ -2,8 +2,8 @@
 
 (def ell-ref {x: 23 y: 57.5 z: [1 2 3 true]})
 (def json-ref (string (json ell-ref))) ;; keywords get converted to strings
-;(println "ell: " ell-ref)
-;(println "json: " json-ref)
+;;(println "ell: " ell-ref)
+;;(println "json: " json-ref)
 
 (defn read-from-string (s)
    (let ((in (open-input-string s)))
@@ -23,3 +23,5 @@
 
 (def j2 {"x":23,"y":57.5,"z":[1,2,3,true]}) ; no whitespace
 (assert-equal j2 jref)
+
+(println "[json_test OK]")

--- a/vector.go
+++ b/vector.go
@@ -53,7 +53,10 @@ func newVector(size int, init *LAny) *LAny {
 	for i := 0; i < size; i++ {
 		elements[i] = init
 	}
-	return &LAny{ltype: typeVector, elements: elements}
+	vec := new(LAny)
+	vec.ltype = typeVector
+	vec.elements = elements
+	return vec
 }
 
 func vector(elements ...*LAny) *LAny {
@@ -63,7 +66,10 @@ func vector(elements ...*LAny) *LAny {
 func vectorFromElements(elements []*LAny, count int) *LAny {
 	el := make([]*LAny, count)
 	copy(el, elements[0:count])
-	return &LAny{ltype: typeVector, elements: el}
+	vec := new(LAny)
+	vec.ltype = typeVector
+	vec.elements = el
+	return vec
 }
 
 func copyVector(vec *LAny) *LAny {

--- a/vector.go
+++ b/vector.go
@@ -20,131 +20,92 @@ import (
 	"bytes"
 )
 
-type LVector struct { // <vector>
-	elements []LAny
-}
-
-var typeVector = intern("<vector>")
-
-func isVector(obj LAny) bool {
-	_, ok := obj.(*LVector)
-	return ok
-}
-
-// Type returns the type of the object
-func (*LVector) Type() LAny {
-	return typeVector
-}
-
-// Value returns the object itself for primitive types
-func (ary *LVector) Value() LAny {
-	return ary
-}
-
-// Equal returns true if the object is equal to the argument
-func (ary *LVector) Equal(another LAny) bool {
-	if a, ok := another.(*LVector); ok {
-		alen := len(ary.elements)
-		if alen == len(a.elements) {
-			for i := 0; i < alen; i++ {
-				if !equal(ary.elements[i], a.elements[i]) {
-					return false
-				}
-			}
-			return true
+func vectorEqual(v1 *LAny, v2 *LAny) bool {
+	count := len(v1.elements)
+	if count != len(v2.elements) {
+		return false
+	}
+	for i := 0; i < count; i++ {
+		if !equal(v1.elements[i], v2.elements[i]) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
-func (ary *LVector) String() string {
+func vectorToString(vec *LAny) string {
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	count := len(ary.elements)
+	count := len(vec.elements)
 	if count > 0 {
-		buf.WriteString(ary.elements[0].String())
+		buf.WriteString(vec.elements[0].String())
 		for i := 1; i < count; i++ {
 			buf.WriteString(" ")
-			buf.WriteString(ary.elements[i].String())
+			buf.WriteString(vec.elements[i].String())
 		}
 	}
 	buf.WriteString("]")
 	return buf.String()
 }
 
-func (vec *LVector) Copy() LAny {
-	size := len(vec.elements)
-	elements := make([]LAny, size)
-	for i := 0; i < size; i++ {
-		elements[i] = vec.elements[i].Copy()
-	}
-	return &LVector{elements}
-}
-
-func newVector(size int, init LAny) *LVector {
-	elements := make([]LAny, size)
+func newVector(size int, init *LAny) *LAny {
+	elements := make([]*LAny, size)
 	for i := 0; i < size; i++ {
 		elements[i] = init
 	}
-	return &LVector{elements}
+	return &LAny{ltype: typeVector, elements: elements}
 }
 
-func vector(elements ...LAny) LAny {
+func vector(elements ...*LAny) *LAny {
 	return vectorFromElements(elements, len(elements))
 }
 
-func vectorFromElements(elements []LAny, count int) LAny {
-	el := make([]LAny, count)
+func vectorFromElements(elements []*LAny, count int) *LAny {
+	el := make([]*LAny, count)
 	copy(el, elements[0:count])
-	return &LVector{el}
+	return &LAny{ltype: typeVector, elements: el}
 }
 
-func copyVector(a *LVector) *LVector {
-	elements := make([]LAny, len(a.elements))
-	copy(elements, a.elements)
-	return &LVector{elements}
+func copyVector(vec *LAny) *LAny {
+	size := len(vec.elements)
+	elements := make([]*LAny, size)
+	copy(elements, vec.elements)
+	return vectorFromElements(elements, size)
 }
 
-func vectorLength(ary LAny) (int, error) {
-	if a, ok := ary.(*LVector); ok {
-		return len(a.elements), nil
-	}
-	return 1, TypeError(typeVector, ary)
-}
-
-func vectorSet(ary LAny, idx int, obj LAny) error {
-	if a, ok := ary.(*LVector); ok {
-		if idx < 0 || idx >= len(a.elements) {
+func vectorSet(vec *LAny, idx int, obj *LAny) error {
+	if isVector(vec) {
+		if idx < 0 || idx >= len(vec.elements) {
 			return Error("Vector index out of range")
 		}
-		a.elements[idx] = obj
+		vec.elements[idx] = obj
 		return nil
 	}
-	return TypeError(typeVector, ary)
+	return TypeError(typeVector, vec)
 }
 
-func vectorRef(ary LAny, idx int) (LAny, error) {
-	if a, ok := ary.(*LVector); ok {
-		if idx < 0 || idx >= len(a.elements) {
+func vectorRef(vec *LAny, idx int) (*LAny, error) {
+	if isVector(vec) {
+		if idx < 0 || idx >= len(vec.elements) {
 			return nil, Error("Vector index out of range")
 		}
-		return a.elements[idx], nil
+		return vec.elements[idx], nil
 	}
-	return nil, TypeError(typeVector, ary)
+	return nil, TypeError(typeVector, vec)
 }
 
-func toVector(obj LAny) (LAny, error) {
-	switch t := obj.(type) {
-	case *LList:
-		return listToVector(t), nil
-	case *LVector:
-		return t, nil
-	case *LStruct:
-		return structToVector(t), nil
-	case LString:
-		return stringToVector(t), nil
+func toVector(obj *LAny) (*LAny, error) {
+	switch obj.ltype {
+	case typeVector:
+		return obj, nil
+	case typeList:
+		return listToVector(obj), nil
+	case typeStruct:
+		return structToVector(obj), nil
+	case typeString:
+		return stringToVector(obj), nil
 	}
-	return nil, Error("Cannot convert ", obj.Type(), " to <vector>")
+	return nil, Error("Cannot convert ", obj.ltype, " to <vector>")
 }
 
 /*


### PR DESCRIPTION
Major redo, to avoid using golang interfaces for basic operation. About 15% faster as a result, although the union style ell object wastes memory. Oh well.

Also, LAny now has become *LOB, and most of the other types went away.
